### PR TITLE
DM-9812: Clean up outputs from CharacterizeImageTask and CalibrateTask

### DIFF
--- a/policy/datasets.yaml
+++ b/policy/datasets.yaml
@@ -441,7 +441,19 @@ srcMatch:
     python: lsst.afw.table.BaseCatalog
     tables: raw
     template: ''
+srcMatchFull:  # Denormalized matches from CalibrateTask
+    persistable: BaseCatalog
+    storage: FitsCatalogStorage
+    python: lsst.afw.table.BaseCatalog
+    tables: raw
+    template: ''
 deepCoadd_srcMatch:
+    persistable: BaseCatalog
+    storage: FitsCatalogStorage
+    python: lsst.afw.table.BaseCatalog
+    tables: raw
+    template: ''
+deepCoadd_srcMatchFull:  # Denormalized matches from MeasureMergedCoaddSourcesTask
     persistable: BaseCatalog
     storage: FitsCatalogStorage
     python: lsst.afw.table.BaseCatalog


### PR DESCRIPTION
Denormalized matches (srcMatchFull) are the matches (srcMatch)
written in a denormalized format that uses more space but is
more convenient to read.