### PR TITLE
DM-10728: Add incomplete entry for new photoCalib dataset.

### DIFF
--- a/policy/datasets.yaml
+++ b/policy/datasets.yaml
@@ -441,6 +441,12 @@ srcMatchFull:  # Denormalized matches from CalibrateTask
     python: lsst.afw.table.BaseCatalog
     tables: raw
     template: ''
+photoCalib:
+    persistable: PhotoCalib
+    storage: FitsCatalogStorage
+    python: lsst.afw.image.PhotoCalib
+    tables: raw
+    template: ''
 deepCoadd_measMatch:  # Matches from MeasureMergedCoaddSourcesTask
     persistable: BaseCatalog
     storage: FitsCatalogStorage


### PR DESCRIPTION
This will store photometric calibration outputs from meas_mosaic and
jointcal.