### PR TITLE
DM-11136: Write calib outputs to data root, not calib root

### DIFF
--- a/python/lsst/obs/base/cameraMapper.py
+++ b/python/lsst/obs/base/cameraMapper.py
@@ -367,7 +367,7 @@ class CameraMapper(dafPersist.Mapper):
 
                     if name == "calibrations":
                         mapping = cls(datasetType, subPolicy, self.registry, self.calibRegistry, calibStorage,
-                                      provided=provided)
+                                      provided=provided, dataRoot=rootStorage)
                     else:
                         mapping = cls(datasetType, subPolicy, self.registry, rootStorage, provided=provided)
                     self.keyDict.update(mapping.keys())


### PR DESCRIPTION
This allows the user to review the results before they 'go live'
and potentially get used by active processes.