### PR TITLE
DM-11268: YamlCamera: add crosstalk support

### DIFF
--- a/python/lsst/obs/base/yamlCamera.py
+++ b/python/lsst/obs/base/yamlCamera.py
@@ -89,6 +89,8 @@ class YamlCamera(cameraGeom.Camera):
             detectorConfig.pitchDeg = ccd['pitch']
             detectorConfig.yawDeg = ccd['yaw']
             detectorConfig.rollDeg = ccd['roll']
+            if 'crosstalk' in ccd:
+                detectorConfig.crosstalk = ccd['crosstalk']
 
         return detectorConfigs
 


### PR DESCRIPTION
The DetectorConfig can now take an optional crosstalk matrix.