### PR TITLE
DM-11607: Use mkdtemp in tests

### DIFF
--- a/tests/testComposite.py
+++ b/tests/testComposite.py
@@ -26,22 +26,20 @@ import gc
 import os
 import shutil
 import unittest
-import lsst.utils.tests
-from lsst.utils import getPackageDir
+import tempfile
 
+import lsst.utils.tests
 import lsst.daf.persistence as dafPersist
 import lsst.daf.persistence.test as dpTest
-import lsst.utils.tests
-from lsst.utils import getPackageDir
+
+ROOT = os.path.abspath(os.path.dirname(__file__))
 
 
 class TestCompositeTestCase(unittest.TestCase):
     """A test case for composite object i/o."""
 
     def setUp(self):
-        packageDir = getPackageDir('obs_base')
-        self.testData = os.path.join(packageDir, 'tests', 'composite')
-        self.tearDown()
+        self.testData = tempfile.mkdtemp(dir=ROOT, prefix='TestCompositeTestCase-')
         self.firstRepoPath = os.path.join(self.testData, 'repo1')
         self.objA = dpTest.TestObject("abc")
         self.objB = dpTest.TestObject("def")
@@ -189,9 +187,7 @@ class TestGenericAssembler(unittest.TestCase):
     """A test case for the generic assembler feature of composite datasets."""
 
     def setUp(self):
-        packageDir = getPackageDir('obs_base')
-        self.testData = os.path.join(packageDir, 'tests', 'genericAssembler')
-        self.tearDown()
+        self.testData = tempfile.mkdtemp(dir=ROOT, prefix='TestGenericAssembler-')
         self.firstRepoPath = os.path.join(self.testData, 'repo1')
         self.secondRepoPath = os.path.join(self.testData, 'repo2')
         self.objA = dpTest.TestObject("abc")
@@ -379,8 +375,7 @@ class TestSubset(unittest.TestCase):
     """A test case for composite object subset keyword."""
 
     def setUp(self):
-        packageDir = getPackageDir('obs_base')
-        self.testData = os.path.join(packageDir, 'tests', 'compositeSubset')
+        self.testData = tempfile.mkdtemp(dir=ROOT, prefix='TestSubset-')
         self.firstRepoPath = os.path.join(self.testData, 'repo1')
         self.objA1 = dpTest.TestObject("abc")
         self.objA2 = dpTest.TestObject("ABC")
@@ -446,8 +441,7 @@ class TestInputOnly(unittest.TestCase):
     """A test case for composite input keyword."""
 
     def setUp(self):
-        packageDir = getPackageDir('obs_base')
-        self.testData = os.path.join(packageDir, 'tests', 'composite')
+        self.testData = tempfile.mkdtemp(dir=ROOT, prefix='TestInputOnly-')
         self.firstRepoPath = os.path.join(self.testData, 'repo1')
         self.objA = dpTest.TestObject("abc")
         self.objB = dpTest.TestObject("def")

--- a/tests/testDM-329.py
+++ b/tests/testDM-329.py
@@ -24,29 +24,28 @@
 
 
 import unittest
-import lsst.utils.tests
+import os
 
+import lsst.utils.tests
 import lsst.afw.image
 import lsst.daf.persistence as dafPersist
 import lsst.obs.base
 import lsst.pex.policy as pexPolicy
-from lsst.utils import getPackageDir
 
-import os
 
-testDir = os.path.relpath(os.path.join(getPackageDir('obs_base'), 'tests'))
+ROOT = os.path.abspath(os.path.dirname(__file__))
 
 
 class MinMapper2(lsst.obs.base.CameraMapper):
     packageName = 'larry'
 
     def __init__(self):
-        policy = pexPolicy.Policy.createPolicy(os.path.join(testDir, 'MinMapper2.paf'))
+        policy = pexPolicy.Policy.createPolicy(os.path.join(ROOT, 'MinMapper2.paf'))
         lsst.obs.base.CameraMapper.__init__(self,
                                             policy=policy,
-                                            repositoryDir=testDir,
-                                            root=testDir,
-                                            registry=os.path.join(testDir, 'cfhtls.sqlite3'))
+                                            repositoryDir=ROOT,
+                                            root=ROOT,
+                                            registry=os.path.join(ROOT, 'cfhtls.sqlite3'))
         return
 
     def _transformId(self, dataId):
@@ -69,7 +68,7 @@ class DM329TestCase(unittest.TestCase):
         for i in (1, 2, 3):
             loc = mapper.map("other", dict(ccd=35, hdu=i))
             expectedLocations = ["bar-35.fits[%d]" % (i,)]
-            self.assertEqual(loc.getStorage().root, testDir)
+            self.assertEqual(loc.getStorage().root, ROOT)
             self.assertEqual(loc.getLocations(), expectedLocations)
             image = butler.get("other", ccd=35, hdu=i, immediate=True)
             self.assertIsInstance(image, lsst.afw.image.ImageF)

--- a/tests/testFindParentMapper.py
+++ b/tests/testFindParentMapper.py
@@ -26,13 +26,14 @@ import filecmp
 import os
 import shutil
 import unittest
+import tempfile
 import lsst.utils.tests
 from lsst.utils import getPackageDir
 
 import lsst.daf.persistence as dafPersist
 import lsst.daf.persistence.test as dpTest
-import lsst.utils.tests
-from lsst.utils import getPackageDir
+
+ROOT = os.path.abspath(os.path.dirname(__file__))
 
 
 class TestFindParentMapperV1Butler(unittest.TestCase):
@@ -41,9 +42,7 @@ class TestFindParentMapperV1Butler(unittest.TestCase):
     """
 
     def setUp(self):
-        packageDir = getPackageDir('obs_base')
-        self.testDir = os.path.join(packageDir, 'tests', 'findParentMapper')
-
+        self.testDir = tempfile.mkdtemp(dir=ROOT, prefix='TestFindParentMapperV1Butler-')
         self.parentRepoDir = os.path.join(self.testDir, 'parentRepo')
         os.makedirs(self.parentRepoDir)
 

--- a/tests/testPolicy.py
+++ b/tests/testPolicy.py
@@ -23,20 +23,21 @@
 #
 
 import unittest
+import tempfile
 import lsst.utils.tests
 
 import lsst.daf.persistence as dafPersist
 import lsst.daf.persistence.test as dpTest
-from lsst.utils import getPackageDir
 import os
 import shutil
 import yaml
 
+ROOT = os.path.abspath(os.path.dirname(__file__))
+
 
 class TestPolicyInRepo(unittest.TestCase):
     def setUp(self):
-        packageDir = getPackageDir('obs_base')
-        self.testData = os.path.join(packageDir, 'tests', 'TestPolicyInRepo')
+        self.testData = tempfile.mkdtemp(dir=ROOT, prefix='TestPolicyInRepo-')
 
     def tearDown(self):
         if os.path.exists(self.testData):


### PR DESCRIPTION
This fixes the problem with races in pytest xdist.