### PR TITLE
DM-11332: Get FITS image write options into the persistence framework

### DIFF
--- a/policy/CalibrationMappingDictionary.paf
+++ b/policy/CalibrationMappingDictionary.paf
@@ -77,4 +77,8 @@ definitions: {
         default: false
         maxOccurs: 1
     }
+    recipe: {
+        type: policy
+        description: "Recipe name for writing"
+    }
 }

--- a/policy/DatasetMappingDictionary.paf
+++ b/policy/DatasetMappingDictionary.paf
@@ -31,4 +31,8 @@ definitions: {
         type: string
         description: "Tables to use for queries of the registry"
     }
+    recipe: {
+        type: policy
+        description: "Recipe name for writing"
+    }
 }

--- a/policy/ExposureMappingDictionary.paf
+++ b/policy/ExposureMappingDictionary.paf
@@ -41,4 +41,8 @@ definitions: {
         type: string
         description: "Columns to use for queries of the registry"
     }
+    recipe: {
+        type: policy
+        description: "Recipe name for writing"
+    }
 }

--- a/policy/ImageMappingDictionary.paf
+++ b/policy/ImageMappingDictionary.paf
@@ -36,4 +36,8 @@ definitions: {
         type: string
         description: "Columns to use for queries of the registry"
     }
+    recipe: {
+        type: policy
+        description: "Recipe name for writing"
+    }
 }

--- a/policy/writeRecipes.yaml
+++ b/policy/writeRecipes.yaml
@@ -1,0 +1,42 @@
+# FITS images
+FitsStorage:
+  # Default: no compression
+  default:
+    image: &default
+      compression:
+        algorithm: NONE
+      scaling:
+        algorithm: NONE
+    mask:
+      <<: *default
+    variance:
+      <<: *default
+
+  # Lossless compression
+  lossless:
+    image: &lossless
+      compression:
+        algorithm: GZIP_SHUFFLE
+      scaling:
+        algorithm: NONE
+    mask:
+      <<: *lossless
+    variance:
+      <<: *lossless
+
+  # Basic lossy (quantizing) compression
+  lossyBasic:
+    image: &lossyBasic
+      compression:
+        algorithm: RICE
+      scaling:
+        algorithm: STDEV_POSITIVE
+        maskPlanes: ["NO_DATA"]
+        bitpix: 32
+        quantizeLevel: 10.0
+        quantizePad: 10.0
+    mask:
+      <<: *lossless
+    variance:
+      <<: *lossyBasic
+

--- a/python/lsst/obs/base/cameraMapper.py
+++ b/python/lsst/obs/base/cameraMapper.py
@@ -26,8 +26,11 @@ import os
 import pyfits  # required by _makeDefectsDict until defects are written as AFW tables
 import re
 import weakref
+import yaml
+import collections
 import lsst.daf.persistence as dafPersist
 from . import ImageMapping, ExposureMapping, CalibrationMapping, DatasetMapping
+import lsst.daf.base as dafBase
 import lsst.afw.geom as afwGeom
 import lsst.afw.image as afwImage
 import lsst.afw.table as afwTable
@@ -264,6 +267,7 @@ class CameraMapper(dafPersist.Mapper):
         self.keyDict = dict()
 
         self._initMappings(policy, self.rootStorage, calibStorage, provided=None)
+        self._initWriteRecipes()
 
         # Camera geometry
         self.cameraDataLocation = None  # path to camera geometry config file
@@ -409,6 +413,12 @@ class CameraMapper(dafPersist.Mapper):
                     if subPolicy["storage"] == "FitsStorage":  # a FITS image
                         setMethods("md", bypassImpl=lambda datasetType, pythonType, location, dataId:
                                    afwImage.readMetadata(location.getLocationsWithRoot()[0]))
+
+                        # Add support for configuring FITS compression
+                        addName = "add_" + datasetType
+                        if not hasattr(self, addName):
+                            setattr(self, addName, self.getImageCompressionSettings)
+
                         if name == "exposures":
                             setMethods("wcs", bypassImpl=lambda datasetType, pythonType, location, dataId:
                                        afwImage.makeWcs(
@@ -625,6 +635,11 @@ class CameraMapper(dafPersist.Mapper):
         if cls.packageName is None:
             raise ValueError('class variable packageName must not be None')
         return cls.packageName
+
+    @classmethod
+    def getPackageDir(cls):
+        """Return the base directory of this package"""
+        return getPackageDir(cls.getPackageName())
 
     def map_camera(self, dataId, write=False):
         """Map a camera dataset."""
@@ -1062,6 +1077,112 @@ class CameraMapper(dafPersist.Mapper):
         """
         return self.registry
 
+    def getImageCompressionSettings(self, datasetType, dataId):
+        """Stuff image compression settings into a daf.base.PropertySet
+
+        This goes into the ButlerLocation's "additionalData", which gets
+        passed into the boost::persistence framework.
+
+        Parameters
+        ----------
+        datasetType : `str`
+            Type of dataset for which to get the image compression settings.
+        dataId : `dict`
+            Dataset identifier.
+
+        Returns
+        -------
+        additionalData : `lsst.daf.base.PropertySet`
+            Image compression settings.
+        """
+        mapping = self.mappings[datasetType]
+        recipeName = mapping.recipe
+        storageType = mapping.storage
+        if storageType not in self._writeRecipes:
+            return lsst.daf.base.PropertySet()
+        if recipeName not in self._writeRecipes[storageType]:
+            raise RuntimeError("Unrecognized write recipe for datasetType %s (storage type %s): %s" %
+                               (datasetType, storageType, recipeName))
+        recipe = self._writeRecipes[storageType][recipeName].deepCopy()
+        seed = hash(tuple(dataId.items())) % 2**31
+        for plane in ("image", "mask", "variance"):
+            if recipe.exists(plane + ".scaling.seed") and recipe.get(plane + ".scaling.seed") == 0:
+                recipe.set(plane + ".scaling.seed", seed)
+        return recipe
+
+    def _initWriteRecipes(self):
+        """Read the recipes for writing files
+
+        These recipes are currently used for configuring FITS compression,
+        but they could have wider uses for configuring different flavors
+        of the storage types. A recipe is referred to by a symbolic name,
+        which has associated settings. These settings are stored as a
+        `PropertySet` so they can easily be passed down to the
+        boost::persistence framework as the "additionalData" parameter.
+
+        The list of recipes is written in YAML. A default recipe and
+        some other convenient recipes are in obs_base/policy/writeRecipes.yaml
+        and these may be overridden or supplemented by the individual obs_*
+        packages' own policy/writeRecipes.yaml files.
+
+        Recipes are grouped by the storage type. Currently, only the
+        ``FitsStorage`` storage type uses recipes, which uses it to
+        configure FITS image compression.
+
+        Each ``FitsStorage`` recipe for FITS compression should define
+        "image", "mask" and "variance" entries, each of which may contain
+        "compression" and "scaling" entries. Defaults will be provided for
+        any missing elements under "compression" and "scaling".
+
+        The allowed entries under "compression" are:
+
+        * algorithm (string): compression algorithm to use
+        * rows (int): number of rows per tile (0 = entire dimension)
+        * columns (int): number of columns per tile (0 = entire dimension)
+        * quantizeLevel (float): cfitsio quantization level
+
+        The allowed entries under "scaling" are:
+
+        * algorithm (string): scaling algorithm to use
+        * bitpix (int): bits per pixel (0,8,16,32,64,-32,-64)
+        * fuzz (bool): fuzz the values when quantising floating-point values?
+        * seed (long): seed for random number generator when fuzzing
+        * maskPlanes (list of string): mask planes to ignore when doing statistics
+        * quantizeLevel: divisor of the standard deviation for STDEV_* scaling
+        * quantizePad: number of stdev to allow on the low side (for STDEV_POSITIVE/NEGATIVE)
+        * bscale: manually specified BSCALE (for MANUAL scaling)
+        * bzero: manually specified BSCALE (for MANUAL scaling)
+
+        A very simple example YAML recipe:
+
+            FitsStorage:
+              default:
+                image: &default
+                  compression:
+                    algorithm: GZIP_SHUFFLE
+                mask: *default
+                variance: *default
+        """
+        recipesFile = os.path.join(getPackageDir("obs_base"), "policy", "writeRecipes.yaml")
+        recipes = dafPersist.Policy(recipesFile)
+        supplementsFile = os.path.join(self.getPackageDir(), "policy", "writeRecipes.yaml")
+        if os.path.exists(supplementsFile) and supplementsFile != recipesFile:
+            supplements = dafPersist.Policy(supplementsFile)
+            # Don't allow overrides, only supplements
+            intersection = set(recipes.names()).intersection(set(supplements.names()))
+            if intersection:
+                raise RuntimeError("Recipes provided in %s may not override those in %s: %s" %
+                                   (supplementsFile, recipesFile, intersection))
+            recipes.update(overrides)
+
+        self._writeRecipes = {}
+        validationMenu = {'FitsStorage': validateRecipeFitsStorage,}
+        for storageType in recipes.names(True):
+            if "default" not in recipes[storageType]:
+                raise RuntimeError("No 'default' recipe defined for storage type %s in %s" %
+                                   (storageType, recipesFile))
+            self._writeRecipes[storageType] = validationMenu[storageType](recipes[storageType])
+
 
 def exposureFromImage(image, dataId=None, mapper=None, logger=None, setVisitInfo=True):
     """Generate an Exposure from an image-like object
@@ -1113,3 +1234,77 @@ def exposureFromImage(image, dataId=None, mapper=None, logger=None, setVisitInfo
                 exposure.getInfo().setVisitInfo(visitInfo)
 
     return exposure
+
+
+def validateRecipeFitsStorage(recipes):
+    """Validate recipes for FitsStorage
+
+    The recipes are supplemented with default values where appropriate.
+
+    TODO: replace this custom validation code with Cerberus (DM-11846)
+
+    Parameters
+    ----------
+    recipes : `lsst.daf.persistence.Policy`
+        FitsStorage recipes to validate.
+
+    Returns
+    -------
+    validated : `lsst.daf.base.PropertySet`
+        Validated FitsStorage recipe.
+
+    Raises
+    ------
+    `RuntimeError`
+        If validation fails.
+    """
+    # Schemas define what should be there, and the default values (and by the default
+    # value, the expected type).
+    compressionSchema = {
+        "algorithm": "NONE",
+        "rows": 1,
+        "columns": 0,
+        "quantizeLevel": 0.0,
+    }
+    scalingSchema = {
+        "algorithm": "NONE",
+        "bitpix": 0,
+        "maskPlanes": ["NO_DATA"],
+        "seed": 0,
+        "quantizeLevel": 4.0,
+        "quantizePad": 5.0,
+        "fuzz": True,
+        "bscale": 1.0,
+        "bzero": 0.0,
+    }
+
+    def checkUnrecognized(entry, allowed, description):
+        """Check to see if the entry contains unrecognised keywords"""
+        unrecognized = set(entry.keys()) - set(allowed)
+        if unrecognized:
+            raise RuntimeError(
+                "Unrecognized entries when parsing image compression recipe %s: %s" %
+                (description, unrecognized))
+
+    validated = {}
+    for name in recipes.names(True):
+        checkUnrecognized(recipes[name], ["image", "mask", "variance"], name)
+        rr = dafBase.PropertySet()
+        validated[name] = rr
+        for plane in ("image", "mask", "variance"):
+            checkUnrecognized(recipes[name][plane], ["compression", "scaling"],
+                              name + "->" + plane)
+
+            for settings, schema in (("compression", compressionSchema),
+                                     ("scaling", scalingSchema)):
+                prefix = plane + "." + settings
+                if settings not in recipes[name][plane]:
+                    for key in schema:
+                        rr.set(prefix + "." + key, schema[key])
+                    continue
+                entry = recipes[name][plane][settings]
+                checkUnrecognized(entry, schema.keys(), name + "->" + plane + "->" + settings)
+                for key in schema:
+                    value = type(schema[key])(entry[key]) if key in entry else schema[key]
+                    rr.set(prefix + "." + key, value)
+    return validated

--- a/tests/test_cameraMapper.py
+++ b/tests/test_cameraMapper.py
@@ -54,6 +54,9 @@ class BaseMapper(lsst.obs.base.CameraMapper):
         lsst.obs.base.CameraMapper.__init__(self, policy=policy, repositoryDir=ROOT, root=ROOT)
         return
 
+    @classmethod
+    def getPackageDir(cls):
+        return "/path/to/nowhere"
 
 class MinMapper1(lsst.obs.base.CameraMapper):
     packageName = 'larry'
@@ -70,6 +73,10 @@ class MinMapper1(lsst.obs.base.CameraMapper):
     def getCameraName(cls):
         """Return the name of the camera that this CameraMapper is for."""
         return "min"
+
+    @classmethod
+    def getPackageDir(cls):
+        return "/path/to/nowhere"
 
 
 class MinMapper2(lsst.obs.base.CameraMapper):
@@ -97,6 +104,10 @@ class MinMapper2(lsst.obs.base.CameraMapper):
         """Return the name of the camera that this CameraMapper is for."""
         return "min"
 
+    @classmethod
+    def getPackageDir(cls):
+        return "/path/to/nowhere"
+
 
 # does not assign packageName
 class MinMapper3(lsst.obs.base.CameraMapper):
@@ -105,6 +116,35 @@ class MinMapper3(lsst.obs.base.CameraMapper):
         policy = dafPersist.Policy(os.path.join(ROOT, "MinMapper1.paf"))
         lsst.obs.base.CameraMapper.__init__(self, policy=policy, repositoryDir=ROOT, root=ROOT)
         return
+
+    @classmethod
+    def getPackageDir(cls):
+        return "/path/to/nowhere"
+
+
+def checkCompression(testCase, additionalData):
+    """Check that compression settings are present
+
+    We check that we can access the required settings, and that
+    the seed is non-zero (zero causes lsst.afw.math.Random to fail).
+    """
+    for plane in ("image", "mask", "variance"):
+        for entry in ("compression.algorithm",
+                      "compression.columns",
+                      "compression.rows",
+                      "compression.quantizeLevel",
+                      "scaling.algorithm",
+                      "scaling.bitpix",
+                      "scaling.maskPlanes",
+                      "scaling.seed",
+                      "scaling.quantizeLevel",
+                      "scaling.quantizePad",
+                      "scaling.fuzz",
+                      "scaling.bscale",
+                      "scaling.bzero",
+                      ):
+            additionalData.get(plane + "." + entry)
+        testCase.assertNotEqual(additionalData.get(plane + ".scaling.seed"), 0)
 
 
 class Mapper1TestCase(unittest.TestCase):
@@ -188,7 +228,8 @@ class Mapper2TestCase(unittest.TestCase):
         self.assertEqual(loc.getStorageName(), "FitsStorage")
         self.assertEqual(loc.getLocations(), ["foo-13.fits"])
         self.assertEqual(loc.getStorage().root, ROOT)
-        self.assertEqual(loc.getAdditionalData().toString(), "ccd = 13\n")
+        self.assertEqual(loc.getAdditionalData().get("ccd"), 13)
+        checkCompression(self, loc.getAdditionalData())
 
     def testSubMap(self):
         if hasattr(afwGeom, 'makePointI'):
@@ -206,8 +247,12 @@ class Mapper2TestCase(unittest.TestCase):
         self.assertEqual(loc.getStorageName(), "FitsStorage")
         self.assertEqual(loc.getLocations(), ["foo-13.fits"])
         self.assertEqual(loc.getStorage().root, ROOT)
-        self.assertEqual(loc.getAdditionalData().toString(),
-                         'ccd = 13\nheight = 400\nllcX = 200\nllcY = 100\nwidth = 300\n')
+        self.assertEqual(loc.getAdditionalData().get("ccd"), 13)
+        self.assertEqual(loc.getAdditionalData().get("width"), 300)
+        self.assertEqual(loc.getAdditionalData().get("height"), 400)
+        self.assertEqual(loc.getAdditionalData().get("llcX"), 200)
+        self.assertEqual(loc.getAdditionalData().get("llcY"), 100)
+        checkCompression(self, loc.getAdditionalData())
 
         loc = mapper.map("raw_sub", {"ccd": 13, "bbox": bbox, "imageOrigin": "PARENT"}, write=True)
         self.assertEqual(loc.getPythonType(), "lsst.afw.image.ExposureU")
@@ -215,9 +260,13 @@ class Mapper2TestCase(unittest.TestCase):
         self.assertEqual(loc.getStorageName(), "FitsStorage")
         self.assertEqual(loc.getLocations(), ["foo-13.fits"])
         self.assertEqual(loc.getStorage().root, ROOT)
-        self.assertEqual(loc.getAdditionalData().toString(),
-                         'ccd = 13\nheight = 400\nimageOrigin = "PARENT"\n'
-                         'llcX = 200\nllcY = 100\nwidth = 300\n')
+        self.assertEqual(loc.getAdditionalData().get("ccd"), 13)
+        self.assertEqual(loc.getAdditionalData().get("width"), 300)
+        self.assertEqual(loc.getAdditionalData().get("height"), 400)
+        self.assertEqual(loc.getAdditionalData().get("llcX"), 200)
+        self.assertEqual(loc.getAdditionalData().get("llcY"), 100)
+        self.assertEqual(loc.getAdditionalData().get("imageOrigin"), "PARENT")
+        checkCompression(self, loc.getAdditionalData())
 
     def testCatalogExtras(self):
         butler = dafPersist.Butler(root=ROOT, mapper=MinMapper2)
@@ -337,8 +386,11 @@ class Mapper2TestCase(unittest.TestCase):
         expectedLocations = ["flat-05Am03-fi.fits"]
         self.assertEqual(loc.getStorage().root, expectedRoot)
         self.assertEqual(loc.getLocations(), expectedLocations)
-        self.assertEqual(loc.getAdditionalData().toString(),
-                         'ccd = 13\nderivedRunId = "05Am03"\nfilter = "i"\nvisit = 787650\n')
+        self.assertEqual(loc.getAdditionalData().get("ccd"), 13)
+        self.assertEqual(loc.getAdditionalData().get("visit"), 787650)
+        self.assertEqual(loc.getAdditionalData().get("derivedRunId"), "05Am03")
+        self.assertEqual(loc.getAdditionalData().get("filter"), "i")
+        checkCompression(self, loc.getAdditionalData())
 
     def testNames(self):
         self.assertEqual(MinMapper2.getCameraName(), "min")

--- a/tests/test_dm-329.py
+++ b/tests/test_dm-329.py
@@ -54,6 +54,10 @@ class MinMapper2(lsst.obs.base.CameraMapper):
     def _extractDetectorName(self, dataId):
         return "Detector"
 
+    @classmethod
+    def getPackageDir(cls):
+        return "/path/to/nowhere"
+
 
 class DM329TestCase(unittest.TestCase):
 

--- a/tests/test_outputRoot.py
+++ b/tests/test_outputRoot.py
@@ -54,6 +54,10 @@ class MinMapper1(lsst.obs.base.CameraMapper):
     def std_x(self, item, dataId):
         return float(item)
 
+    @classmethod
+    def getPackageDir(cls):
+        return "/path/to/nowhere"
+
 
 class OutputRootTestCase(unittest.TestCase):
     """A test case for output roots."""


### PR DESCRIPTION
Introduces the concept of recipes for writing. The policy/writeRecipes.yaml
file has the recipes, allowing recipes to be selected by symbolic name.
Overrides can be specified in the obs package. We include recipes for
lossless FITS image compression (the default) and lossy compression
(included for convenience because I hope to evaluate it and activate
it soon).