### PR TITLE
DM-11701: Remove processDonut definitions.

### DIFF
--- a/policy/datasets.yaml
+++ b/policy/datasets.yaml
@@ -616,17 +616,6 @@ donutDriver_config:
     storage: ConfigStorage
     python: lsst.donut.donutDriver.DonutDriverConfig
     template: config/DonutDriver.py
-processDonut_config:
-    persistable: Config
-    python: lsst.donut.processDonut.ProcessDonutConfig
-    storage: ConfigStorage
-    template: config/processDonut.py
-processDonut_metadata:
-    persistable: PropertySet
-    storage: BoostStorage
-    python: lsst.daf.base.PropertySet
-    tables: raw
-    template: metadata/processDonut.boost
 fitDonut_config:
     persistable: Config
     python: lsst.donut.fitDonut.FitDonutConfig


### PR DESCRIPTION
After refactoring the donut pipeline, these policy
definitions are no longer necessary.