### PR TITLE
Add mappers for qa-plot parquet tables

### DIFF
--- a/policy/datasets.yaml
+++ b/policy/datasets.yaml
@@ -638,3 +638,18 @@ donut_schema:
     storage: FitsCatalogStorage
     python: lsst.afw.table.SourceCatalog
     template: schema/donut.fits
+qaTableCoadd:
+    persistable: None
+    python: __builtin__.str
+    storage: TextStorage
+    template: plots/%(filter)s/tract-%(tract)d/%(description)s.parq
+qaTableColor:
+    persistable: None
+    python: __builtin__.str
+    storage: TextStorage
+    template: plots/color/tract-%(tract)d/%(description)s.parq
+qaTableVisit:
+    persistable: None
+    python: __builtin__.str
+    storage: TextStorage
+    template: ''

--- a/policy/datasets.yaml
+++ b/policy/datasets.yaml
@@ -640,16 +640,16 @@ donut_schema:
     template: schema/donut.fits
 qaTableCoadd:
     persistable: None
-    python: __builtin__.str
+    python: builtins.str
     storage: TextStorage
     template: plots/%(filter)s/tract-%(tract)d/%(description)s.parq
 qaTableColor:
     persistable: None
-    python: __builtin__.str
+    python: builtins.str
     storage: TextStorage
     template: plots/color/tract-%(tract)d/%(description)s.parq
 qaTableVisit:
     persistable: None
-    python: __builtin__.str
+    python: builtins.str
     storage: TextStorage
     template: ''


### PR DESCRIPTION
The QA plots need (for now) to write parquet tables of the summarized source catalogs.  This defines the filenames for those tables.  I'm not sure whether it's OK to have `qaTableVisit` defined here with a blank template as I do, with then only `template` defined in `obs_subaru`, but maybe @PaulPrice can confirm?