### PR TITLE
Stop posix lookups for calibs

### DIFF
--- a/python/lsst/obs/base/cameraMapper.py
+++ b/python/lsst/obs/base/cameraMapper.py
@@ -252,7 +252,8 @@ class CameraMapper(dafPersist.Mapper):
         if needCalibRegistry:
             if calibStorage:
                 self.calibRegistry = self._setupRegistry("calibRegistry", "calib", calibRegistry, policy,
-                                                         "calibRegistryPath", calibStorage)
+                                                         "calibRegistryPath", calibStorage,
+                                                         posixIfNoSql=False)  # NB never use posix for calibs
             else:
                 raise RuntimeError(
                     "'needCalibRegistry' is true in Policy, but was unable to locate a repo at " +


### PR DESCRIPTION
Calibs should never be looked up without a registry.
This is because they have validity ranges, and just grabbing
the first one you find that matches on disk, ignoring possible
validity args you've been given is not OK, as you might get
what you want, you might not, and you won't know. Any breaking
changes this introduces are OK, as nobody should ever have been
doing it this way.