### PR TITLE
DM-11138: Add jointcal_wcs and jointcal_photoCalib datatasets.

### DIFF
--- a/policy/datasets.yaml
+++ b/policy/datasets.yaml
@@ -451,7 +451,19 @@ srcMatchFull:  # Denormalized matches from CalibrateTask
     python: lsst.afw.table.BaseCatalog
     tables: raw
     template: ''
-photoCalib:
+jointcal_wcs:  # Astrometric calibration produced by meas_mosaic/jointcal
+    persistable: SkyWcs
+    storage: FitsCatalogStorage
+    python: lsst.afw.geom.SkyWcs
+    tables: raw
+    template: ''
+jointcal_photoCalib:  # Photometric calibration produced by meas_mosaic/jointcal
+    persistable: PhotoCalib
+    storage: FitsCatalogStorage
+    python: lsst.afw.image.PhotoCalib
+    tables: raw
+    template: ''
+photoCalib:  # old meas_mosaic/jointcal output; deprecated in favor of jointcal_photoCalib
     persistable: PhotoCalib
     storage: FitsCatalogStorage
     python: lsst.afw.image.PhotoCalib

--- a/policy/exposures.yaml
+++ b/policy/exposures.yaml
@@ -71,6 +71,7 @@ raw:
     level: Ccd
     tables: raw
     template: ''
+# old meas_mosaic/jointcal output; deprecated in favor of jointcal_wcs, but still need to read old outputs
 wcs:
     persistable: ExposureI
     storage: FitsStorage


### PR DESCRIPTION
"wcs" and "photoCalib" are retained for reading old outputs but deprecated.