### PR TITLE
DM-13163: Refactor ap_pipe to use CmdLineTask primitives

### DIFF
--- a/policy/datasets.yaml
+++ b/policy/datasets.yaml
@@ -791,3 +791,14 @@ fgcmStandardStars: # Catalog of standard stars with magnitudes as generated from
     tables: raw
     python: lsst.afw.table.BaseCatalog
     template: fgcm-process/fgcmStandardStars-%(fgcmcycle)02d.fits
+apPipe_config:
+    persistable: Config
+    python: lsst.ap.pipe.ApPipeConfig
+    storage: ConfigStorage
+    template: config/apPipe.py
+apPipe_metadata:
+    persistable: PropertySet
+    storage: BoostStorage
+    python: lsst.daf.base.PropertySet
+    tables: raw
+    template: ''


### PR DESCRIPTION
This PR registers dataset types for configs and metadata persisted by `ApPipeTask`.