### PR TITLE
DM-13770: Add datasets to enable writing object tables to parquet

### DIFF
--- a/policy/datasets.yaml
+++ b/policy/datasets.yaml
@@ -802,3 +802,8 @@ apPipe_metadata:
     python: lsst.daf.base.PropertySet
     tables: raw
     template: ''
+deepCoadd_obj: #consolidated multi-band object tables from coadd
+    persistable: ignored
+    storage: FitsCatalogStorage
+    python: lsst.qa.explorer.table.ParquetTable
+    template: deepCoadd-results/merged/%(tract)d/%(patch)s/obj-%(tract)d-%(patch)s.parq

--- a/policy/datasets.yaml
+++ b/policy/datasets.yaml
@@ -803,6 +803,11 @@ apPipe_metadata:
     tables: raw
     template: ''
 deepCoadd_obj: #consolidated multi-band object tables from coadd
+    description: >
+        Consolidated coadd multi-band object table, a merge of
+        deepCoadd_meas, deepCoadd_forced_src and deepCoadd_ref tables for multiple bands.
+        This is a pandas DataFrame with a multi-level column index; access a particular
+        subcatalog as df['meas']['HSC-R'], e.g.
     persistable: ignored
     storage: FitsCatalogStorage
     python: lsst.qa.explorer.table.ParquetTable

--- a/policy/datasets.yaml
+++ b/policy/datasets.yaml
@@ -807,3 +807,8 @@ deepCoadd_obj: #consolidated multi-band object tables from coadd
     storage: FitsCatalogStorage
     python: lsst.qa.explorer.table.ParquetTable
     template: deepCoadd-results/merged/%(tract)d/%(patch)s/obj-%(tract)d-%(patch)s.parq
+writeObjectTable_config:
+    persistable: Config
+    python: lsst.qa.explorer.writeParquet.WriteObjectTableConfig
+    storage: ConfigStorage
+    template: config/writeObjectTable.py


### PR DESCRIPTION
The `deepCoadd_obj` table dataset is a "fake" fits table, meaning the python object it points to has `readFits`/`writeFits` objects that actually write to and read from parquet files.  This is a temporary workaround before a `ParquetStorage` storage type is defined (DM-13876).