### PR TITLE
DM-13876: implement ParquetStorage butler storage mechanism

### DIFF
--- a/policy/datasets.yaml
+++ b/policy/datasets.yaml
@@ -811,7 +811,7 @@ deepCoadd_obj: #consolidated multi-band object tables from coadd
         see MultilevelParquetTable documentation for more.
     persistable: ignored
     storage: ParquetStorage
-    python: lsst.qa.explorer.parquetTable.MultilevelParquetTable # pandas.DataFrame to write
+    python: lsst.qa.explorer.parquetTable.MultilevelParquetTable
     template: deepCoadd-results/merged/%(tract)d/%(patch)s/obj-%(tract)d-%(patch)s.parq
 writeObjectTable_config:
     persistable: Config

--- a/policy/datasets.yaml
+++ b/policy/datasets.yaml
@@ -803,6 +803,12 @@ apPipe_metadata:
     tables: raw
     template: ''
 deepCoadd_obj: #consolidated multi-band object tables from coadd
+    description: >
+        Consolidated coadd multi-band object table, a merge of
+        deepCoadd_meas, deepCoadd_forced_src and deepCoadd_ref tables for multiple bands.
+        This is stored as a DataFrame with a multi-level column index; access a particular
+        subtable with, e.g. catalog.to_df(columns=dict(dataset='meas', filter='HSC-G'));
+        see MultilevelParquetTable documentation for more.
     persistable: ignored
     storage: ParquetStorage
     python: lsst.qa.explorer.parquetTable.MultilevelParquetTable # pandas.DataFrame to write

--- a/policy/datasets.yaml
+++ b/policy/datasets.yaml
@@ -803,17 +803,12 @@ apPipe_metadata:
     tables: raw
     template: ''
 deepCoadd_obj: #consolidated multi-band object tables from coadd
-    description: >
-        Consolidated coadd multi-band object table, a merge of
-        deepCoadd_meas, deepCoadd_forced_src and deepCoadd_ref tables for multiple bands.
-        This is a pandas DataFrame with a multi-level column index; access a particular
-        subcatalog as df['meas']['HSC-R'], e.g.
     persistable: ignored
-    storage: FitsCatalogStorage
-    python: lsst.qa.explorer.table.ParquetTable
+    storage: ParquetStorage
+    python: lsst.qa.explorer.parquetTable.MultilevelParquetTable # pandas.DataFrame to write
     template: deepCoadd-results/merged/%(tract)d/%(patch)s/obj-%(tract)d-%(patch)s.parq
 writeObjectTable_config:
     persistable: Config
-    python: lsst.qa.explorer.writeParquet.WriteObjectTableConfig
+    python: lsst.qa.explorer.writeObjectTable.WriteObjectTableConfig
     storage: ConfigStorage
     template: config/writeObjectTable.py


### PR DESCRIPTION
This changes the storage type and dataset type of deepCoadd_obj to use the new implementation of ParquetStorage and ParquetTable.