### PR TITLE
DM-14377: calexp_camera is an ImageF

### DIFF
--- a/policy/datasets.yaml
+++ b/policy/datasets.yaml
@@ -735,8 +735,8 @@ skyCorr:  # Result of sky correction
     template: ''
 calexp_camera:  # Camera-level view of calexp after sky correction
     template: ''
-    persistable: ExposureF
-    python: lsst.afw.image.ExposureF
+    persistable: ImageF
+    python: lsst.afw.image.ImageF
     storage: FitsStorage
     level: None
 verify_job:  # Dataset to hold metrics, specs and measurements from lsst_verify as lsst.verify.job


### PR DESCRIPTION
Before this change calexp_camera was passed as an ImageF in ci_hsc,
whereas in policy an ExposureF is listed.