### PR TITLE
DM-9852: Add DCR template images

### DIFF
--- a/policy/datasets.yaml
+++ b/policy/datasets.yaml
@@ -948,4 +948,36 @@ deepCoadd_qa_tract:
     storage: ParquetStorage
     python: lsst.qa.explorer.parquetTable.MultilevelParquetTable
     template: deepCoadd-results/qa/%(tract)d/qa-%(tract)d.parq
+dcrDiff_config:
+    template:      config/dcrDiff.py
+    python:        lsst.pipe.tasks.imageDifference.ImageDifferenceConfig
+    persistable:   Config
+    storage:       ConfigStorage
+    tables:        'raw'
+dcrDiff_metadata:
+    template:      ''
+    python:        lsst.daf.base.PropertySet
+    persistable:   PropertySet
+    storage:       BoostStorage
+    tables:        'raw'
+dcrDiff_diaSrc:
+    description: "Catalog of sources detected on dcrDiff_differenceExp."
+    template:      ''
+    python:        lsst.afw.table.SourceCatalog
+    persistable:   SourceCatalog
+    storage:       FitsCatalogStorage
+    tables:        'raw'
+dcrDiff_diaSrc_schema:
+    template:      schema/dcrDiff_diaSrc.fits
+    python:        lsst.afw.table.SourceCatalog
+    persistable:   SourceCatalog
+    storage:       FitsCatalogStorage
+    tables:        'raw'
+dcrDiff_kernelSrc:
+    description: "Source catalog of stars that were used to compute the matching kernel in ImageDifferenceTask."
+    template:      ''
+    python:        lsst.afw.table.SourceCatalog
+    persistable:   SourceCatalog
+    storage:       FitsCatalogStorage
+    tables:        'raw'
 

--- a/policy/exposures.yaml
+++ b/policy/exposures.yaml
@@ -140,3 +140,21 @@ dcrCoadd_nImage:
     python: lsst.afw.image.ImageU
     template: dcrCoadd/%(filter)s%(subfilter)dof%(numSubfilters)d/%(tract)d/%(patch)s_nImage.fits
     level: Skytile
+dcrDiff_differenceExp:
+    description: "The result of image differencing an image against a dcrCoadd."
+    template:      ''
+    python:        lsst.afw.image.ExposureF
+    persistable:   ExposureF
+    storage:       FitsStorage
+    level:         Ccd
+    tables:        'raw'
+dcrDiff_matchedExp:
+    description: >
+      The result of forward-modeling chromatic effects, warping, and PSF-matching a dcrCoadd
+      to the image to be differenced against.
+    template:      ''
+    python:        lsst.afw.image.ExposureF
+    persistable:   ExposureF
+    storage:       FitsStorage
+    level:         Ccd
+    tables:        'raw'


### PR DESCRIPTION
Create the dataset definitions needed for image differencing using DCR templates (DM-14738).