### PR TITLE
DM-8828: Support proper motions in reference catalogs

### DIFF
--- a/policy/datasets.yaml
+++ b/policy/datasets.yaml
@@ -410,8 +410,8 @@ ccdExposureId_bits:
     template: ignored
 ref_cat:
     description: "An external reference catalog, read by LoadIndexedReferenceObjectsTask."
-    persistable: SourceCatalog
-    python: lsst.afw.table.SourceCatalog
+    persistable: SimpleCatalog
+    python: lsst.afw.table.SimpleCatalog
     storage: FitsCatalogStorage
     table: ignored
     template: ref_cats/%(name)s/%(pixel_id)s.fits


### PR DESCRIPTION
Change type of reference catalog from SourceCatalog to SimpleCatalog, as per our standard (we don't want or need the extra fields)