### PR TITLE
DM-6640: IsrTask is not a valid CmdLineTask

### DIFF
--- a/policy/datasets.yaml
+++ b/policy/datasets.yaml
@@ -458,6 +458,19 @@ isr_metadata:
     python: lsst.daf.base.PropertySet
     tables: raw
     template: ''
+runIsr_config:
+    description: "Configuration for RunIsrTask, which retargets IsrTask to the correct camera-specific class."
+    persistable: Config
+    storage: ConfigStorage
+    python: lsst.ip.isr.RunIsrConfig
+    template: config/runIsr.py
+runIsr_metadata:
+    description: "Metadata for RunIsrTask, which retargets IsrTask to the correct camera-specific class."
+    persistable: PropertySet
+    storage: YamlStorage
+    python: lsst.daf.base.PropertySet
+    tables: raw
+    template: ''
 icSrc:
     description: >
         High signal-to-noise source catalog produced by CharacterizeImageTask (a subset of `src`).


### PR DESCRIPTION
This ticket adds a stand-alone runIsr.py script, as well as ensuring that runIsr.py and processCcd.py read the same ISR configuration files.
