### PR TITLE
Change creation pattern and support distortion in YamlCamera

### DIFF
--- a/python/lsst/obs/base/yamlCamera.py
+++ b/python/lsst/obs/base/yamlCamera.py
@@ -194,13 +194,13 @@ def makeBBoxFromList(ylist):
     return afwGeom.BoxI(afwGeom.PointI(x0, y0), afwGeom.ExtentI(xsize, ysize))
 
 
-def makeTransformDict(nativeSys, transformYamlDict, plateScale):
+def makeTransformDict(nativeSys, transformDict, plateScale):
     """Make a dictionary of TransformPoint2ToPoint2s from yaml, mapping from nativeSys
 
     Parameters
     ----------
     nativeSys : `lsst.afw.cameraGeom.CameraSys`
-    transformYamlDict : `dict`
+    transformDict : `dict`
         A dict specifying parameters of transforms; keys are camera system names.
     plateScale : `lsst.geom.Angle`
         The size of a pixel in angular units/mm (e.g. 20 arcsec/mm for LSST)
@@ -208,9 +208,9 @@ def makeTransformDict(nativeSys, transformYamlDict, plateScale):
     Returns
     -------
     transforms : `dict`
-        A dict of lsst.afw.cameraGeom.CameraSys : lsst.afw.geom.TransformPoint2ToPoint2
+        A dict of `lsst.afw.cameraGeom.CameraSys` : `lsst.afw.geom.TransformPoint2ToPoint2`
 
-    The resulting dict's keys are CameraSys,
+    The resulting dict's keys are `~lsst.afw.cameraGeom.CameraSys`,
     and the values are Transforms *from* NativeSys *to* CameraSys
     """
     # As other comments note this is required, and this is one function where it's assumed
@@ -218,7 +218,7 @@ def makeTransformDict(nativeSys, transformYamlDict, plateScale):
 
     resMap = dict()
 
-    for key, transform in transformYamlDict.items():
+    for key, transform in transformDict.items():
         transformType = transform["transformType"]
         knownTransformTypes = ["affine", "radial"]
         if transformType not in knownTransformTypes:

--- a/python/lsst/obs/base/yamlCamera.py
+++ b/python/lsst/obs/base/yamlCamera.py
@@ -23,181 +23,318 @@ import yaml
 
 import numpy as np
 import lsst.afw.cameraGeom as cameraGeom
+import lsst.geom as geom
 import lsst.afw.geom as afwGeom
 from lsst.afw.table import AmpInfoCatalog, AmpInfoTable
-from lsst.afw.cameraGeom.cameraFactory import makeDetector
+from lsst.afw.cameraGeom.cameraFactory import makeDetectorData
+
+__all__ = ["makeCamera"]
 
 
-class YamlCamera(cameraGeom.Camera):
-    """The Commissioning Camera (comCam)
+def makeCamera(cameraFile):
+    """An imaging camera (e.g. the LSST 3Gpix camera)
 
     Parameters
     ----------
-    cameraYamlFile : `str`
+    cameraFile : `str`
         Camera description YAML file.
+
+    Return a `lsst.afw.cameraGeom.Camera`
     """
 
-    def __init__(self, cameraYamlFile):
-        with open(cameraYamlFile) as fd:
-            cameraParams = yaml.load(fd, Loader=yaml.Loader)
+    with open(cameraFile) as fd:
+        cameraParams = yaml.load(fd, Loader=yaml.Loader)
 
-        plateScale = afwGeom.Angle(cameraParams["plateScale"], afwGeom.arcseconds)
-        # radial coefficients of the form [0, no units, 1/rad but usually 0, 1/rad^2, ...]
-        # Radial distortion is modeled as a radial polynomial that converts from focal plane radius (in mm)
-        # to field angle (in radians). The coefficients are divided by the plate scale (in mm/radians)
-        # meaning that C1 is always 1.
-        radialCoeffs = np.array(cameraParams["radialCoeffs"])/plateScale.asRadians()
-        fieldAngleToFocalPlane = afwGeom.makeRadialTransform(radialCoeffs)
-        focalPlaneToFieldAngle = fieldAngleToFocalPlane.inverted()
-        cameraTransformMap = cameraGeom.TransformMap(cameraGeom.FOCAL_PLANE,
-                                                     {cameraGeom.FIELD_ANGLE: focalPlaneToFieldAngle})
-        detectorList = self._makeDetectorList(cameraParams["CCDs"], focalPlaneToFieldAngle)
-        cameraGeom.Camera.__init__(self, cameraParams["name"], detectorList, cameraTransformMap)
+    cameraName = cameraParams["name"]
 
-    def _makeDetectorList(self, ccdParams, focalPlaneToFieldAngle):
-        """Make a list of detectors
+    #
+    # Handle distortion models.
+    #
+    plateScale = afwGeom.Angle(cameraParams["plateScale"], afwGeom.arcseconds)
+    nativeSys = cameraGeom.CameraSys(cameraParams["transforms"].pop("nativeSys"))
+    transforms = makeTransformDict(nativeSys, cameraParams["transforms"], plateScale)
 
-        Parameters
-        ----------
-        ccdParams : `dict`
-            Dict of YAML descriptions of CCDs.
-        focalPlaneToFieldAngle : `lsst.afw.geom.TransformPoint2ToPoint2`
-            Angle from FOCAL_PLANE to FIELD_ANGLE coordinates.
+    ccdParams = cameraParams["CCDs"]
+    detectorConfigList = makeDetectorConfigList(ccdParams)
 
-        Returns
-        -------
-        `list` of `lsst.afw.cameraGeom.Detector`
-            list of detectors in this camera.
-        """
-        detectorList = []
-        detectorConfigList = self._makeDetectorConfigList(ccdParams)
-        for ccd, detectorConfig in zip(ccdParams.values(), detectorConfigList):
-            ampInfoCatalog = self._makeAmpInfoCatalog(ccd)
-            detector = makeDetector(detectorConfig, ampInfoCatalog, focalPlaneToFieldAngle)
-            detectorList.append(detector)
-        return detectorList
+    ampInfoCatDict = {}
+    for (ccdName, ccdValues), detectorConfig in zip(ccdParams.items(), detectorConfigList):
+        ampInfoCatDict[ccdName] = makeAmpInfoCatalog(ccdValues)
 
-    def _makeDetectorConfigList(self, ccdParams):
-        """Make a list of detector configs
+    return makeCameraFromCatalogs(cameraName, detectorConfigList, nativeSys, transforms, ampInfoCatDict)
 
-        Returns
-        -------
-        `list` of `lsst.afw.cameraGeom.DetectorConfig`
-            A list of detector configs.
-        """
-        detectorConfigs = []
-        for name, ccd in ccdParams.items():
-            detectorConfig = cameraGeom.DetectorConfig()
-            detectorConfigs.append(detectorConfig)
 
-            detectorConfig.name = name
-            detectorConfig.id = ccd['id']
-            detectorConfig.serial = ccd['serial']
-            detectorConfig.detectorType = ccd['detectorType']
-            # This is the orientation we need to put the serial direction along the x-axis
-            detectorConfig.bbox_x0, detectorConfig.bbox_y0 = ccd['bbox'][0]
-            detectorConfig.bbox_x1, detectorConfig.bbox_y1 = ccd['bbox'][1]
-            detectorConfig.pixelSize_x, detectorConfig.pixelSize_y = ccd['pixelSize']
-            detectorConfig.transformDict.nativeSys = ccd['transformDict']['nativeSys']
-            transforms = ccd['transformDict']['transforms']
-            detectorConfig.transformDict.transforms = None if transforms == 'None' else transforms
-            detectorConfig.refpos_x, detectorConfig.refpos_y = ccd['refpos']
-            detectorConfig.offset_x, detectorConfig.offset_y = ccd['offset']
-            detectorConfig.transposeDetector = ccd['transposeDetector']
-            detectorConfig.pitchDeg = ccd['pitch']
-            detectorConfig.yawDeg = ccd['yaw']
-            detectorConfig.rollDeg = ccd['roll']
-            if 'crosstalk' in ccd:
-                detectorConfig.crosstalk = ccd['crosstalk']
+def makeDetectorConfigList(ccdParams):
+    """Make a list of detector configs
 
-        return detectorConfigs
+    Returns
+    -------
+    `list` of `lsst.afw.cameraGeom.DetectorConfig`
+        A list of detector configs.
+    """
+    detectorConfigs = []
+    for name, ccd in ccdParams.items():
+        detectorConfig = cameraGeom.DetectorConfig()
+        detectorConfigs.append(detectorConfig)
 
-    @staticmethod
-    def _makeBBoxFromList(ylist):
-        """Given a list [(x0, y0), (xsize, ysize)], probably from a yaml file,
-        return a BoxI
-        """
-        (x0, y0), (xsize, ysize) = ylist
-        return afwGeom.BoxI(afwGeom.PointI(x0, y0), afwGeom.ExtentI(xsize, ysize))
+        detectorConfig.name = name
+        detectorConfig.id = ccd['id']
+        detectorConfig.serial = ccd['serial']
+        detectorConfig.detectorType = ccd['detectorType']
+        # This is the orientation we need to put the serial direction along the x-axis
+        detectorConfig.bbox_x0, detectorConfig.bbox_y0 = ccd['bbox'][0]
+        detectorConfig.bbox_x1, detectorConfig.bbox_y1 = ccd['bbox'][1]
+        detectorConfig.pixelSize_x, detectorConfig.pixelSize_y = ccd['pixelSize']
+        detectorConfig.transformDict.nativeSys = ccd['transformDict']['nativeSys']
+        transforms = ccd['transformDict']['transforms']
+        detectorConfig.transformDict.transforms = None if transforms == 'None' else transforms
+        detectorConfig.refpos_x, detectorConfig.refpos_y = ccd['refpos']
+        detectorConfig.offset_x, detectorConfig.offset_y = ccd['offset']
+        detectorConfig.transposeDetector = ccd['transposeDetector']
+        detectorConfig.pitchDeg = ccd['pitch']
+        detectorConfig.yawDeg = ccd['yaw']
+        detectorConfig.rollDeg = ccd['roll']
+        if 'crosstalk' in ccd:
+            detectorConfig.crosstalk = ccd['crosstalk']
 
-    def _makeAmpInfoCatalog(self, ccd):
-        """Construct an amplifier info catalog
-        """
-        # Much of this will need to be filled in when we know it.
-        assert len(ccd['amplifiers']) > 0
-        amp = list(ccd['amplifiers'].values())[0]
+    return detectorConfigs
 
-        rawBBox = self._makeBBoxFromList(amp['rawBBox'])  # total in file
-        xRawExtent, yRawExtent = rawBBox.getDimensions()
 
-        from lsst.afw.table import LL, LR, UL, UR
-        readCorners = dict(LL=LL, LR=LR, UL=UL, UR=UR)
+def makeAmpInfoCatalog(ccd):
+    """Construct an amplifier info catalog
+    """
+    # Much of this will need to be filled in when we know it.
+    assert len(ccd['amplifiers']) > 0
+    amp = list(ccd['amplifiers'].values())[0]
 
-        schema = AmpInfoTable.makeMinimalSchema()
+    rawBBox = makeBBoxFromList(amp['rawBBox'])  # total in file
+    xRawExtent, yRawExtent = rawBBox.getDimensions()
 
-        linThreshKey = schema.addField('linearityThreshold', type=float)
-        linMaxKey = schema.addField('linearityMaximum', type=float)
-        linUnitsKey = schema.addField('linearityUnits', type=str, size=9)
-        hduKey = schema.addField('hdu', type=np.int32)
-        # end placeholder
-        self.ampInfoDict = {}
-        ampCatalog = AmpInfoCatalog(schema)
-        for name, amp in sorted(ccd['amplifiers'].items(), key=lambda x: x[1]['hdu']):
-            record = ampCatalog.addNew()
-            record.setName(name)
-            record.set(hduKey, amp['hdu'])
+    from lsst.afw.table import LL, LR, UL, UR
+    readCorners = dict(LL=LL, LR=LR, UL=UL, UR=UR)
 
-            ix, iy = amp['ixy']
-            perAmpData = amp['perAmpData']
-            if perAmpData:
-                x0, y0 = 0, 0           # origin of data within each amp image
-            else:
-                x0, y0 = ix*xRawExtent, iy*yRawExtent
+    schema = AmpInfoTable.makeMinimalSchema()
 
-            rawDataBBox = self._makeBBoxFromList(amp['rawDataBBox'])  # Photosensitive area
-            xDataExtent, yDataExtent = rawDataBBox.getDimensions()
-            record.setBBox(afwGeom.BoxI(
-                afwGeom.PointI(ix*xDataExtent, iy*yDataExtent), rawDataBBox.getDimensions()))
+    linThreshKey = schema.addField('linearityThreshold', type=float)
+    linMaxKey = schema.addField('linearityMaximum', type=float)
+    linUnitsKey = schema.addField('linearityUnits', type=str, size=9)
+    hduKey = schema.addField('hdu', type=np.int32)
+    # end placeholder
 
-            rawBBox = self._makeBBoxFromList(amp['rawBBox'])
-            rawBBox.shift(afwGeom.ExtentI(x0, y0))
-            record.setRawBBox(rawBBox)
+    ampCatalog = AmpInfoCatalog(schema)
+    for name, amp in sorted(ccd['amplifiers'].items(), key=lambda x: x[1]['hdu']):
+        record = ampCatalog.addNew()
+        record.setName(name)
+        record.set(hduKey, amp['hdu'])
 
-            rawDataBBox = self._makeBBoxFromList(amp['rawDataBBox'])
-            rawDataBBox.shift(afwGeom.ExtentI(x0, y0))
-            record.setRawDataBBox(rawDataBBox)
+        ix, iy = amp['ixy']
+        perAmpData = amp['perAmpData']
+        if perAmpData:
+            x0, y0 = 0, 0           # origin of data within each amp image
+        else:
+            x0, y0 = ix*xRawExtent, iy*yRawExtent
 
-            rawSerialOverscanBBox = self._makeBBoxFromList(amp['rawSerialOverscanBBox'])
-            rawSerialOverscanBBox.shift(afwGeom.ExtentI(x0, y0))
-            record.setRawHorizontalOverscanBBox(rawSerialOverscanBBox)
+        rawDataBBox = makeBBoxFromList(amp['rawDataBBox'])  # Photosensitive area
+        xDataExtent, yDataExtent = rawDataBBox.getDimensions()
+        record.setBBox(afwGeom.BoxI(
+            afwGeom.PointI(ix*xDataExtent, iy*yDataExtent), rawDataBBox.getDimensions()))
 
-            rawParallelOverscanBBox = self._makeBBoxFromList(amp['rawParallelOverscanBBox'])
-            rawParallelOverscanBBox.shift(afwGeom.ExtentI(x0, y0))
-            record.setRawVerticalOverscanBBox(rawParallelOverscanBBox)
+        rawBBox = makeBBoxFromList(amp['rawBBox'])
+        rawBBox.shift(afwGeom.ExtentI(x0, y0))
+        record.setRawBBox(rawBBox)
 
-            rawSerialPrescanBBox = self._makeBBoxFromList(amp['rawSerialPrescanBBox'])
-            rawSerialPrescanBBox.shift(afwGeom.ExtentI(x0, y0))
-            record.setRawPrescanBBox(rawSerialPrescanBBox)
+        rawDataBBox = makeBBoxFromList(amp['rawDataBBox'])
+        rawDataBBox.shift(afwGeom.ExtentI(x0, y0))
+        record.setRawDataBBox(rawDataBBox)
 
-            if perAmpData:
-                record.setRawXYOffset(afwGeom.Extent2I(ix*xRawExtent, iy*yRawExtent))
-            else:
-                record.setRawXYOffset(afwGeom.Extent2I(0, 0))
+        rawSerialOverscanBBox = makeBBoxFromList(amp['rawSerialOverscanBBox'])
+        rawSerialOverscanBBox.shift(afwGeom.ExtentI(x0, y0))
+        record.setRawHorizontalOverscanBBox(rawSerialOverscanBBox)
 
-            record.setReadoutCorner(readCorners[amp['readCorner']])
-            record.setGain(amp['gain'])
-            record.setReadNoise(amp['readNoise'])
-            record.setSaturation(amp['saturation'])
-            record.setHasRawInfo(True)
-            # flip data when assembling if needs be (e.g. data from the serial at the top of a CCD)
-            flipX, flipY = amp.get("flipXY")
+        rawParallelOverscanBBox = makeBBoxFromList(amp['rawParallelOverscanBBox'])
+        rawParallelOverscanBBox.shift(afwGeom.ExtentI(x0, y0))
+        record.setRawVerticalOverscanBBox(rawParallelOverscanBBox)
 
-            record.setRawFlipX(flipX)
-            record.setRawFlipY(flipY)
-            # linearity placeholder stuff
-            record.setLinearityCoeffs([float(val) for val in amp['linearityCoeffs']])
-            record.setLinearityType(amp['linearityType'])
-            record.set(linThreshKey, float(amp['linearityThreshold']))
-            record.set(linMaxKey, float(amp['linearityMax']))
-            record.set(linUnitsKey, "DN")
-        return ampCatalog
+        rawSerialPrescanBBox = makeBBoxFromList(amp['rawSerialPrescanBBox'])
+        rawSerialPrescanBBox.shift(afwGeom.ExtentI(x0, y0))
+        record.setRawPrescanBBox(rawSerialPrescanBBox)
+
+        if perAmpData:
+            record.setRawXYOffset(afwGeom.Extent2I(ix*xRawExtent, iy*yRawExtent))
+        else:
+            record.setRawXYOffset(afwGeom.Extent2I(0, 0))
+
+        record.setReadoutCorner(readCorners[amp['readCorner']])
+        record.setGain(amp['gain'])
+        record.setReadNoise(amp['readNoise'])
+        record.setSaturation(amp['saturation'])
+        record.setHasRawInfo(True)
+        # flip data when assembling if needs be (e.g. data from the serial at the top of a CCD)
+        flipX, flipY = amp.get("flipXY")
+
+        record.setRawFlipX(flipX)
+        record.setRawFlipY(flipY)
+        # linearity placeholder stuff
+        record.setLinearityCoeffs([float(val) for val in amp['linearityCoeffs']])
+        record.setLinearityType(amp['linearityType'])
+        record.set(linThreshKey, float(amp['linearityThreshold']))
+        record.set(linMaxKey, float(amp['linearityMax']))
+        record.set(linUnitsKey, "DN")
+    return ampCatalog
+
+
+def makeBBoxFromList(ylist):
+    """Given a list [(x0, y0), (xsize, ysize)], probably from a yaml file,
+    return a BoxI
+    """
+    (x0, y0), (xsize, ysize) = ylist
+    return afwGeom.BoxI(afwGeom.PointI(x0, y0), afwGeom.ExtentI(xsize, ysize))
+
+
+def makeTransformDict(nativeSys, transformYamlDict, plateScale):
+    """Make a dictionary of TransformPoint2ToPoint2s from yaml, mapping from nativeSys
+
+    Parameters
+    ----------
+    nativeSys : `lsst.afw.cameraGeom.CameraSys`
+    transformYamlDict : `dict`
+        A dict specifying parameters of transforms; keys are camera system names.
+    plateScale : `afwGeom.Angle`
+        The size of a pixel in angular units/mm (e.g. 20 arcsec/mm for LSST)
+
+    Returns
+    -------
+    transforms : `dict`
+        A dict of lsst.afw.cameraGeom.CameraSys : lsst.afw.geom.TransformPoint2ToPoint2
+
+    The resulting dict's keys are CameraSys,
+    and the values are Transforms *from* NativeSys *to* CameraSys
+    """
+    # As other comments note this is required, and this is one function where it's assumed
+    assert nativeSys == cameraGeom.FOCAL_PLANE, "Cameras with nativeSys != FOCAL_PLANE are not supported."
+
+    resMap = dict()
+
+    for key, transform in transformYamlDict.items():
+        transformType = transform["transformType"]
+        knownTransformTypes = ["affine", "radial"]
+        if transformType not in knownTransformTypes:
+            raise RuntimeError("Saw unknown transform type for %s: %s (known types are: [%s])" % (
+                key, transform["transformType"], ", ".join(knownTransformTypes)))
+
+        if transformType == "affine":
+            affine = geom.AffineTransform(np.array(transform["linear"]),
+                                          np.array(transform["translation"]))
+
+            transform = afwGeom.makeTransform(affine)
+        elif transformType == "radial":
+            # radial coefficients of the form [0, 1 (no units), C2 (rad), usually 0, C3 (rad^2), ...]
+            # Radial distortion is modeled as a radial polynomial that converts from focal plane radius
+            # (in mm) to field angle (in radians). The provided coefficients are divided by the plate
+            # scale (in radians/mm) meaning that C1 is always 1.
+            radialCoeffs = np.array(transform["coeffs"])
+
+            radialCoeffs *= plateScale.asRadians()
+            transform = afwGeom.makeRadialTransform(radialCoeffs)
+        else:
+            raise RuntimeError("Impossible condition \"%s\" is not in: [%s])" % (
+                transform["transformType"], ", ".join(knownTransformTypes)))
+
+        resMap[cameraGeom.CameraSys(key)] = transform
+
+    return resMap
+
+
+def makeCameraFromCatalogs(cameraName, detectorConfigList, nativeSys, transformDict, ampInfoCatDict,
+                           pupilFactoryClass=cameraGeom.pupil.PupilFactory):
+    """Construct a Camera instance from a dictionary of detector name: AmpInfoCatalog
+
+    Copied from
+        afw/cameraGeom/cameraFactory.py
+    with permission and encouragement from Jim Bosch
+
+    Parameters
+    ----------
+    cameraName : `str`
+        The name of the camera
+    detectorConfig : `list`
+        A list of `lsst.afw.cameraGeom.cameraConfig.DetectorConfig`
+    nativeSys : `lsst.afw.cameraGeom.CameraSys`
+        The native transformation type; must be cameraGeom.FOCAL_PLANE
+    transformDict : `dict`
+        A dict of lsst.afw.cameraGeom.CameraSys : lsst.afw.geom.TransformPoint2ToPoint2
+    ampInfoCatDict : `dict`
+        A dictionary of detector name :
+                           `lsst.afw.table.ampInfo.AmpInfoCatalog`
+    pupilFactoryClass : `type`, optional
+        Class to attach to camera;
+             `lsst.default afw.cameraGeom.PupilFactory`
+
+    Returns
+    -------
+    camera : `lsst.afw.cameraGeom.Camera`
+        New Camera instance.
+    """
+
+    # nativeSys=FOCAL_PLANE seems to be assumed in various places in this file
+    # (e.g. the definition of TAN_PIXELS), despite CameraConfig providing the
+    # illusion that it's configurable.
+    # Note that we can't actually get rid of the nativeSys config option
+    # without breaking lots of on-disk camera configs.
+    assert nativeSys == cameraGeom.FOCAL_PLANE, "Cameras with nativeSys != FOCAL_PLANE are not supported."
+
+    focalPlaneToField = transformDict[cameraGeom.FIELD_ANGLE]
+    transformMapBuilder = cameraGeom.TransformMap.Builder(nativeSys)
+    transformMapBuilder.connect(transformDict)
+
+    # First pass: build a list of all Detector ctor kwargs, minus the
+    # transformMap (which needs information from all Detectors).
+    detectorData = []
+    for detectorConfig in detectorConfigList:
+
+        # Get kwargs that could be used to construct each Detector
+        # if we didn't care about giving each of them access to
+        # all of the transforms.
+        thisDetectorData = makeDetectorData(
+            detectorConfig=detectorConfig,
+            ampInfoCatalog=ampInfoCatDict[detectorConfig.name],
+            focalPlaneToField=focalPlaneToField,
+        )
+
+        # Pull the transforms dictionary out of the data dict; we'll replace
+        # it with a TransformMap argument later.
+        thisDetectorTransforms = thisDetectorData.pop("transforms")
+
+        # Save the rest of the Detector data dictionary for later
+        detectorData.append(thisDetectorData)
+
+        # For reasons I don't understand, some obs_ packages (e.g. HSC) set
+        # nativeSys to None for their detectors (which doesn't seem to be
+        # permitted by the config class!), but they really mean PIXELS. For
+        # backwards compatibility we use that as the default...
+        detectorNativeSys = detectorConfig.transformDict.nativeSys
+        detectorNativeSys = (cameraGeom.PIXELS if detectorNativeSys is None else
+                             cameraGeom.CameraSysPrefix(detectorNativeSys))
+
+        # ...well, actually, it seems that we've always assumed down in C++
+        # that the answer is always PIXELS without ever checking that it is.
+        # So let's assert that it is, since there are hints all over this file
+        # (e.g. the definition of TAN_PIXELS) that other parts of the codebase
+        # have regularly made that assumption as well.  Note that we can't
+        # actually get rid of the nativeSys config option without breaking
+        # lots of on-disk camera configs.
+        assert detectorNativeSys == cameraGeom.PIXELS, \
+            "Detectors with nativeSys != PIXELS are not supported."
+        detectorNativeSys = cameraGeom.CameraSys(detectorNativeSys, detectorConfig.name)
+
+        # Add this detector's transform dict to the shared TransformMapBuilder
+        transformMapBuilder.connect(detectorNativeSys, thisDetectorTransforms)
+
+    # Now that we've collected all of the Transforms, we can finally build the
+    # (immutable) TransformMap.
+    transformMap = transformMapBuilder.build()
+
+    # Second pass through the detectorConfigs: actually make Detector instances
+    detectorList = [cameraGeom.Detector(transformMap=transformMap, **kw) for kw in detectorData]
+
+    return cameraGeom.Camera(cameraName, detectorList, transformMap, pupilFactoryClass)

--- a/python/lsst/obs/base/yamlCamera.py
+++ b/python/lsst/obs/base/yamlCamera.py
@@ -39,18 +39,21 @@ def makeCamera(cameraFile):
     cameraFile : `str`
         Camera description YAML file.
 
-    Return a `lsst.afw.cameraGeom.Camera`
+    Returns
+    -------
+    camera : `lsst.afw.cameraGeom.Camera`
+        The desired Camera
     """
 
     with open(cameraFile) as fd:
-        cameraParams = yaml.load(fd, Loader=yaml.Loader)
+        cameraParams = yaml.load(fd, Loader=yaml.CLoader)
 
     cameraName = cameraParams["name"]
 
     #
     # Handle distortion models.
     #
-    plateScale = afwGeom.Angle(cameraParams["plateScale"], afwGeom.arcseconds)
+    plateScale = geom.Angle(cameraParams["plateScale"], geom.arcseconds)
     nativeSys = cameraGeom.CameraSys(cameraParams["transforms"].pop("nativeSys"))
     transforms = makeTransformDict(nativeSys, cameraParams["transforms"], plateScale)
 
@@ -58,7 +61,7 @@ def makeCamera(cameraFile):
     detectorConfigList = makeDetectorConfigList(ccdParams)
 
     ampInfoCatDict = {}
-    for (ccdName, ccdValues), detectorConfig in zip(ccdParams.items(), detectorConfigList):
+    for ccdName, ccdValues in ccdParams.items():
         ampInfoCatDict[ccdName] = makeAmpInfoCatalog(ccdValues)
 
     return makeCameraFromCatalogs(cameraName, detectorConfigList, nativeSys, transforms, ampInfoCatDict)
@@ -69,7 +72,7 @@ def makeDetectorConfigList(ccdParams):
 
     Returns
     -------
-    `list` of `lsst.afw.cameraGeom.DetectorConfig`
+    detectorConfig : `list` of `lsst.afw.cameraGeom.DetectorConfig`
         A list of detector configs.
     """
     detectorConfigs = []
@@ -199,7 +202,7 @@ def makeTransformDict(nativeSys, transformYamlDict, plateScale):
     nativeSys : `lsst.afw.cameraGeom.CameraSys`
     transformYamlDict : `dict`
         A dict specifying parameters of transforms; keys are camera system names.
-    plateScale : `afwGeom.Angle`
+    plateScale : `lsst.geom.Angle`
         The size of a pixel in angular units/mm (e.g. 20 arcsec/mm for LSST)
 
     Returns
@@ -247,11 +250,8 @@ def makeTransformDict(nativeSys, transformYamlDict, plateScale):
 
 def makeCameraFromCatalogs(cameraName, detectorConfigList, nativeSys, transformDict, ampInfoCatDict,
                            pupilFactoryClass=cameraGeom.pupil.PupilFactory):
-    """Construct a Camera instance from a dictionary of detector name: AmpInfoCatalog
-
-    Copied from
-        afw/cameraGeom/cameraFactory.py
-    with permission and encouragement from Jim Bosch
+    """Construct a Camera instance from a dictionary of
+       detector name : `lsst.afw.table.ampInfo.AmpInfoCatalog`
 
     Parameters
     ----------
@@ -260,9 +260,9 @@ def makeCameraFromCatalogs(cameraName, detectorConfigList, nativeSys, transformD
     detectorConfig : `list`
         A list of `lsst.afw.cameraGeom.cameraConfig.DetectorConfig`
     nativeSys : `lsst.afw.cameraGeom.CameraSys`
-        The native transformation type; must be cameraGeom.FOCAL_PLANE
+        The native transformation type; must be `lsst.afw.cameraGeom.FOCAL_PLANE`
     transformDict : `dict`
-        A dict of lsst.afw.cameraGeom.CameraSys : lsst.afw.geom.TransformPoint2ToPoint2
+        A dict of lsst.afw.cameraGeom.CameraSys : `lsst.afw.geom.TransformPoint2ToPoint2`
     ampInfoCatDict : `dict`
         A dictionary of detector name :
                            `lsst.afw.table.ampInfo.AmpInfoCatalog`
@@ -274,6 +274,11 @@ def makeCameraFromCatalogs(cameraName, detectorConfigList, nativeSys, transformD
     -------
     camera : `lsst.afw.cameraGeom.Camera`
         New Camera instance.
+
+    Notes
+    ------
+    Copied from `lsst.afw.cameraGeom.cameraFactory` with permission and encouragement
+    from Jim Bosch
     """
 
     # nativeSys=FOCAL_PLANE seems to be assumed in various places in this file


### PR DESCRIPTION
Provide a makeCamera function rather than inheriting from Camera.

The support for distortion models is mostly in makeTransformDict,
and required clarification that all models are
	*from* native *to* other
which is a change from at least some other cameras.

N.b. makeCamera required that we changed a number of methods to be
functions, which accounts for most of the changes.