### PR TITLE
DM-8097: Switch raw to ExposureU and enable raw_sub test

### DIFF
--- a/policy/exposures.yaml
+++ b/policy/exposures.yaml
@@ -83,9 +83,9 @@ calexp:
     template: ''
 raw:
     description: "An image directly from the data acquisition system."
-    persistable: DecoratedImageU
+    persistable: ExposureU
     storage: FitsStorage
-    python: lsst.afw.image.DecoratedImageU
+    python: lsst.afw.image.ExposureU
     level: Ccd
     tables: raw
     template: ''

--- a/python/lsst/obs/base/butler_tests.py
+++ b/python/lsst/obs/base/butler_tests.py
@@ -163,14 +163,14 @@ class ButlerGetTests(metaclass=abc.ABCMeta):
     def test_flat(self):
         self._test_exposure('flat')
 
-    @unittest.skip('Cannot test this, as there is a bug in the butler! DM-8097')
     def test_raw_sub_bbox(self):
         exp = self.butler.get('raw', self.dataIds['raw'], immediate=True)
         bbox = exp.getBBox()
         bbox.grow(-1)
         sub = self.butler.get("raw_sub", self.dataIds['raw'], bbox=bbox, immediate=True)
         self.assertEqual(sub.getImage().getBBox(), bbox)
-        self.assertImagesEqual(sub, exp.Factory(exp, bbox))
+        self.assertImagesEqual(sub.maskedImage.image,
+                               exp.subset(bbox).maskedImage.image)
 
     def test_subset_raw(self):
         for kwargs, expect in self.butler_get_data.raw_subsets:


### PR DESCRIPTION
The raw_sub test would not work with DecoratedImageU because the constructor does not deal with a bounding box properly. Switch raw to ExposureU (which is already the standard in obs packages).