### PR TITLE
DM-19382: Add dataset for preinterp ISR exp.

### DIFF
--- a/policy/exposures.yaml
+++ b/policy/exposures.yaml
@@ -70,6 +70,17 @@ postISRCCD:
     level: Ccd
     tables: raw
     template: ''
+postISRCCD_uninterpolated:
+    description: >
+      The exposure after Instrument Signature Removal is run,
+      without background subtraction, characterization or measurement,
+      with masked pixels left uninterpolated.
+    persistable: ExposureF
+    storage: FitsStorage
+    python: lsst.afw.image.ExposureF
+    level: Ccd
+    tables: raw
+    template: ''
 calexp:
     description: >
       A fully characterized and calibrated exposure, produced by ProcessCcdTask.


### PR DESCRIPTION
Add dataset for uninterpolated ISR exposure.  This allows the interpolation/masking reordering to save the output if needed.