### PR TITLE
DM-21048: Add try block around around setting of filter when reading raws.

### DIFF
--- a/python/lsst/obs/base/cameraMapper.py
+++ b/python/lsst/obs/base/cameraMapper.py
@@ -1030,7 +1030,10 @@ class CameraMapper(dafPersist.Mapper):
         filterName = actualId['filter']
         if self.filters is not None and filterName in self.filters:
             filterName = self.filters[filterName]
-        item.setFilter(afwImage.Filter(filterName))
+        try:
+            item.setFilter(afwImage.Filter(filterName))
+        except pexExcept.NotFoundError:
+            self.log.warn("Filter %s not defined.  Set to UNKNOWN." % (filterName))
 
     def _standardizeExposure(self, mapping, item, dataId, filter=True,
                              trimmed=True, setVisitInfo=True):


### PR DESCRIPTION
This change allows raws to be read even when the filter is not defined.  A warning is logged, but the code continues rather than raising an exception, because there are times when you don't need to know the filter information (e.g. BOT testing).