### PR TITLE
DM-21248: Do not attempt to create a WCS if the exposure is for an amp

### DIFF
--- a/python/lsst/obs/base/cameraMapper.py
+++ b/python/lsst/obs/base/cameraMapper.py
@@ -1080,8 +1080,9 @@ class CameraMapper(dafPersist.Mapper):
 
         # We can only create a WCS if it doesn't already have one and
         # we have either a VisitInfo or exposure metadata.
-        if exposure.getWcs() is None and \
-           (exposure.getInfo().getVisitInfo() is not None or exposure.getMetadata().toDict() != {}):
+        # Do not calculate a WCS if this is an amplifier exposure
+        if mapping.level.lower() != "amp" and exposure.getWcs() is None and \
+           (exposure.getInfo().getVisitInfo() is not None or exposure.getMetadata().toDict()):
             self._createInitialSkyWcs(exposure)
 
         if filter:


### PR DESCRIPTION
It is highly likely that the WCS will never work for amps because
a visit info has not been constructed at this point and amps
do not always have a usable WCS in the headers.