### PR TITLE
DM-21455: Convert subfilter and numSubfilter types to str

### DIFF
--- a/policy/datasets.yaml
+++ b/policy/datasets.yaml
@@ -172,7 +172,7 @@ dcrCoadd_deblendedModel:
     persistable: ignored
     storage: FitsCatalogStorage
     python: lsst.afw.table.SourceCatalog
-    template: dcrCoadd-results/%(filter)s%(subfilter)dof%(numSubfilters)d/%(tract)d/%(patch)s/deblendedModel-%(filter)s%(subfilter)dof%(numSubfilters)d-%(tract)d-%(patch)s.fits
+    template: dcrCoadd-results/%(filter)s%(subfilter)sof%(numSubfilters)s/%(tract)d/%(patch)s/deblendedModel-%(filter)s%(subfilter)sof%(numSubfilters)s-%(tract)d-%(patch)s.fits
 dcrCoadd_deblendedModel_schema:
     persistable: SourceCatalog
     storage: FitsCatalogStorage
@@ -184,7 +184,7 @@ dcrCoadd_deblendedFlux:
     persistable: ignored
     storage: FitsCatalogStorage
     python: lsst.afw.table.SourceCatalog
-    template: dcrCoadd-results/%(filter)s%(subfilter)dof%(numSubfilters)d/%(tract)d/%(patch)s/deblendedFlux-%(filter)s%(subfilter)dof%(numSubfilters)d-%(tract)d-%(patch)s.fits
+    template: dcrCoadd-results/%(filter)s%(subfilter)sof%(numSubfilters)s/%(tract)d/%(patch)s/deblendedFlux-%(filter)s%(subfilter)sof%(numSubfilters)s-%(tract)d-%(patch)s.fits
 dcrCoadd_deblendedFlux_schema:
     persistable: SourceCatalog
     storage: FitsCatalogStorage
@@ -674,7 +674,7 @@ dcrCoadd_calexp_background:
     persistable: PurePythonClass
     storage: FitsCatalogStorage
     python: lsst.afw.math.BackgroundList
-    template: dcrCoadd-results/%(filter)s%(subfilter)dof%(numSubfilters)d/%(tract)d/%(patch)s/bkgd-%(filter)s%(subfilter)dof%(numSubfilters)d-%(tract)d-%(patch)s.fits
+    template: dcrCoadd-results/%(filter)s%(subfilter)sof%(numSubfilters)s/%(tract)d/%(patch)s/bkgd-%(filter)s%(subfilter)sof%(numSubfilters)s-%(tract)d-%(patch)s.fits
 dcrCoadd_peak_schema:
     persistable: PeakCatalog
     storage: FitsCatalogStorage
@@ -684,7 +684,7 @@ dcrCoadd_forced_metadata:
     persistable: PropertySet
     storage: YamlStorage
     python: lsst.daf.base.PropertySet
-    template: dcrCoadd_forcedPhotCoadd_metadata/%(filter)s%(subfilter)dof%(numSubfilters)d/%(tract)d/%(patch)s.yaml
+    template: dcrCoadd_forcedPhotCoadd_metadata/%(filter)s%(subfilter)sof%(numSubfilters)s/%(tract)d/%(patch)s.yaml
 dcrCoadd_forced_src_schema:
     persistable: ignored
     storage: FitsCatalogStorage
@@ -711,7 +711,7 @@ dcrCoadd_meas:
     persistable: ignored
     storage: FitsCatalogStorage
     python: lsst.afw.table.SourceCatalog
-    template: dcrCoadd-results/%(filter)s%(subfilter)dof%(numSubfilters)d/%(tract)d/%(patch)s/meas-%(filter)s%(subfilter)dof%(numSubfilters)d-%(tract)d-%(patch)s.fits
+    template: dcrCoadd-results/%(filter)s%(subfilter)sof%(numSubfilters)s/%(tract)d/%(patch)s/meas-%(filter)s%(subfilter)sof%(numSubfilters)s-%(tract)d-%(patch)s.fits
 dcrCoadd_forced_config:
     persistable: Config
     storage: ConfigStorage
@@ -725,7 +725,7 @@ dcrCoadd_forced_src:
     persistable: ignored
     storage: FitsCatalogStorage
     python: lsst.afw.table.SourceCatalog
-    template: dcrCoadd-results/%(filter)s%(subfilter)dof%(numSubfilters)d/%(tract)d/%(patch)s/forced_src-%(filter)s%(subfilter)dof%(numSubfilters)d-%(tract)d-%(patch)s.fits
+    template: dcrCoadd-results/%(filter)s%(subfilter)sof%(numSubfilters)s/%(tract)d/%(patch)s/forced_src-%(filter)s%(subfilter)sof%(numSubfilters)s-%(tract)d-%(patch)s.fits
 dcrCoadd_mergeDet_schema:
     persistable: SourceCatalog
     storage: FitsCatalogStorage
@@ -774,31 +774,31 @@ dcrCoadd_det:
     persistable: ignored
     storage: FitsCatalogStorage
     python: lsst.afw.table.SourceCatalog
-    template: dcrCoadd-results/%(filter)s%(subfilter)dof%(numSubfilters)d/%(tract)d/%(patch)s/det-%(filter)s%(subfilter)dof%(numSubfilters)d-%(tract)d-%(patch)s.fits
+    template: dcrCoadd-results/%(filter)s%(subfilter)sof%(numSubfilters)s/%(tract)d/%(patch)s/det-%(filter)s%(subfilter)sof%(numSubfilters)s-%(tract)d-%(patch)s.fits
 dcrCoadd_measMatch:
     description: "Matches from MeasureMergedDcrCoaddSourcesTask."
     persistable: BaseCatalog
     storage: FitsCatalogStorage
     python: lsst.afw.table.BaseCatalog
     tables: raw
-    template: dcrCoadd-results/%(filter)s%(subfilter)dof%(numSubfilters)d/%(tract)d/%(patch)s/srcMatch-%(filter)s%(subfilter)dof%(numSubfilters)d-%(tract)d-%(patch)s.fits
+    template: dcrCoadd-results/%(filter)s%(subfilter)sof%(numSubfilters)s/%(tract)d/%(patch)s/srcMatch-%(filter)s%(subfilter)sof%(numSubfilters)s-%(tract)d-%(patch)s.fits
 dcrCoadd_measMatchFull:
     description: "Denormalized matches from MeasureMergedDcrCoaddSourcesTask."
     persistable: BaseCatalog
     storage: FitsCatalogStorage
     python: lsst.afw.table.BaseCatalog
     tables: raw
-    template: dcrCoadd-results/%(filter)s%(subfilter)dof%(numSubfilters)d/%(tract)d/%(patch)s/srcMatchFull-%(filter)s%(subfilter)dof%(numSubfilters)d-%(tract)d-%(patch)s.fits
+    template: dcrCoadd-results/%(filter)s%(subfilter)sof%(numSubfilters)s/%(tract)d/%(patch)s/srcMatchFull-%(filter)s%(subfilter)sof%(numSubfilters)s-%(tract)d-%(patch)s.fits
 dcr_makeCoaddTempExp_metadata:
     persistable: PropertySet
     storage: YamlStorage
     python: lsst.daf.base.PropertySet
-    template: dcr_makeCoaddTempExp_metadata/%(filter)s%(subfilter)dof%(numSubfilters)d/%(tract)d/%(patch)s_metadata.yaml
+    template: dcr_makeCoaddTempExp_metadata/%(filter)s%(subfilter)sof%(numSubfilters)s/%(tract)d/%(patch)s_metadata.yaml
 dcr_assembleCoadd_metadata:
     persistable: PropertySet
     storage: YamlStorage
     python: lsst.daf.base.PropertySet
-    template: dcr_assembleCoadd_metadata/%(filter)s%(subfilter)dof%(numSubfilters)d/%(tract)d/%(patch)s.yaml
+    template: dcr_assembleCoadd_metadata/%(filter)s%(subfilter)sof%(numSubfilters)s/%(tract)d/%(patch)s.yaml
 dcr_makeSkyMap_metadata:
     persistable: PropertySet
     storage: YamlStorage

--- a/policy/exposures.yaml
+++ b/policy/exposures.yaml
@@ -148,7 +148,7 @@ dcrCoadd:
     persistable: ExposureF
     storage: FitsStorage
     python: lsst.afw.image.ExposureF
-    template: dcrCoadd/%(filter)s%(subfilter)dof%(numSubfilters)d/%(tract)d/%(patch)s.fits
+    template: dcrCoadd/%(filter)s%(subfilter)sof%(numSubfilters)s/%(tract)d/%(patch)s.fits
     level: Skytile
 dcrCoadd_calexp:
     description: >
@@ -157,7 +157,7 @@ dcrCoadd_calexp:
     persistable: ExposureF
     storage: FitsStorage
     python: lsst.afw.image.ExposureF
-    template: dcrCoadd-results/%(filter)s%(subfilter)dof%(numSubfilters)d/%(tract)d/%(patch)s/calexp-%(filter)s-%(tract)d-%(patch)s.fits
+    template: dcrCoadd-results/%(filter)s%(subfilter)sof%(numSubfilters)s/%(tract)d/%(patch)s/calexp-%(filter)s-%(tract)d-%(patch)s.fits
     level: None
 dcrCoadd_directWarp:
     description: "An image which has been warped so it can be included in a dcrCoaddd."
@@ -172,7 +172,7 @@ dcrCoadd_nImage:
     persistable: ImageU
     storage: FitsStorage
     python: lsst.afw.image.ImageU
-    template: dcrCoadd/%(filter)s%(subfilter)dof%(numSubfilters)d/%(tract)d/%(patch)s_nImage.fits
+    template: dcrCoadd/%(filter)s%(subfilter)sof%(numSubfilters)s/%(tract)d/%(patch)s_nImage.fits
     level: Skytile
 dcrDiff_differenceExp:
     description: "The result of image differencing an image against a dcrCoadd."


### PR DESCRIPTION
This is necessary for compatibility with coadd source detection and measurements using multiband.py . The datasetType in the argument parser is hardcoded as deepCoadd, which lacks these two keys. Since the argument parser defaults to type str for any keys that it finds that are not present in the definitions set by the datasetType, we can either change these keys to match the default type, or define wrappers around the tasks in multiband.py to replace the hardcoded defaults with dcrCoadd. Since this problem is likely to go away with the Gen 3 butler, it seems best to simply change the type. It should be noted that these keys both already had type str in `obs_decam`'s DecamMapper.yaml.