### PR TITLE
DM-21836: Add observation_type to Registry exposure records

### DIFF
--- a/python/lsst/obs/base/ingest_tests.py
+++ b/python/lsst/obs/base/ingest_tests.py
@@ -101,6 +101,20 @@ class IngestTestBase(metaclass=abc.ABCMeta):
         image = self.butler.get("raw.image", self.dataId)
         self.assertImagesEqual(exposure.image, image)
         self.assertEqual(metadata.toDict(), exposure.getMetadata().toDict())
+        self.checkRepo(files=files)
+
+    def checkRepo(self, files=None):
+        """Check the state of the repository after ingest.
+
+        This is an optional hook provided for subclasses; by default it does
+        nothing.
+
+        Parameters
+        ----------
+        files : `list` [`str`], or None
+            List of files to be ingested, or None to use ``self.file``
+        """
+        pass
 
     def testSymLink(self):
         self.config.transfer = "symlink"

--- a/python/lsst/obs/base/ingest_tests.py
+++ b/python/lsst/obs/base/ingest_tests.py
@@ -77,7 +77,7 @@ class IngestTestBase(metaclass=abc.ABCMeta):
 
         Parameters
         ----------
-        files : `list`, [`str`], or None
+        files : `list` [`str`], or None
             List of files to be ingested, or None to use ``self.file``
         """
         if files is None:
@@ -92,7 +92,7 @@ class IngestTestBase(metaclass=abc.ABCMeta):
 
         Parameters
         ----------
-        files : `list`, [`str`], or None
+        files : `list` [`str`], or None
             List of files to be ingested, or None to use ``self.file``
         """
         self.runIngest(files)


### PR DESCRIPTION
This branch includes tests for changes made in daf_butler, but that test code is only run in the concrete obs_ packages (e.g. obs_subaru), not here.
