### PR TITLE
DM-22704: Ensure that the symlink uses an absolute path for ingest in place test

### DIFF
--- a/python/lsst/obs/base/ingest_tests.py
+++ b/python/lsst/obs/base/ingest_tests.py
@@ -138,7 +138,7 @@ class IngestTestBase(metaclass=abc.ABCMeta):
         """
         # symlink into repo root manually
         newPath = os.path.join(self.butler.datastore.root, os.path.basename(self.file))
-        os.symlink(self.file, newPath)
+        os.symlink(os.path.abspath(self.file), newPath)
         self.config.transfer = None
         self.runIngestTest([newPath])
 


### PR DESCRIPTION
If the file path is a relative path the test can sometimes fail
to find the right file depending on whether some other test has
done a chdir.