### PR TITLE
DM-23976: Move shared code from obs packages

### DIFF
--- a/python/lsst/obs/base/instrument.py
+++ b/python/lsst/obs/base/instrument.py
@@ -218,7 +218,7 @@ class Instrument(metaclass=ABCMeta):
         -----
         This method scans the location defined in the ``obsDataPackageDir``
         class attribute for curated calibrations corresponding to the
-        supplied dataset type.  The directory name in the data package much
+        supplied dataset type.  The directory name in the data package must
         match the name of the dataset type. They are assumed to use the
         standard layout and can be read by
         `~lsst.pipe.tasks.read_curated_calibs.read_all` and provide standard

--- a/python/lsst/obs/base/instrument.py
+++ b/python/lsst/obs/base/instrument.py
@@ -153,15 +153,22 @@ class Instrument(metaclass=ABCMeta):
         """
         raise NotImplementedError()
 
-    @abstractmethod
     def writeCuratedCalibrations(self, butler):
         """Write human-curated calibration Datasets to the given Butler with
         the appropriate validity ranges.
 
-        This is a temporary API that should go away once obs_ packages have
-        a standardized approach to this problem.
+        Parameters
+        ----------
+        butler : `lsst.daf.butler.Butler`
+            Butler to use to store these calibrations.
+
+        Notes
+        -----
+        Expected to be called from subclasses.  The base method calls
+        ``writeCameraGeom`` and ``writeStandardTextCuratedCalibrations``.
         """
-        raise NotImplementedError()
+        self.writeCameraGeom(butler)
+        self.writeStandardTextCuratedCalibrations(butler)
 
     def applyConfigOverrides(self, name, config):
         """Apply instrument-specific overrides for a task config.

--- a/python/lsst/obs/base/instrument.py
+++ b/python/lsst/obs/base/instrument.py
@@ -192,9 +192,6 @@ class Instrument(metaclass=ABCMeta):
         """Write the default camera geometry to the butler repository
         with an infinite validity range.
 
-        Expected to be called from an instrument subclass
-        ``writeCuratedCalibrations`` implementation.
-
         Parameters
         ----------
         butler : `lsst.daf.butler.Butler`
@@ -211,9 +208,6 @@ class Instrument(metaclass=ABCMeta):
     def writeStandardTextCuratedCalibrations(self, butler):
         """Write the set of standardized curated text calibrations to
         the repository.
-
-        Expected to be called from an instrument subclass
-        ``writeCuratedCalibrations`` implementation.
 
         Parameters
         ----------

--- a/python/lsst/obs/base/instrument.py
+++ b/python/lsst/obs/base/instrument.py
@@ -46,7 +46,7 @@ class Instrument(metaclass=ABCMeta):
     arguments.
     """
 
-    configPaths = []
+    configPaths = ()
     """Paths to config files to read for specific Tasks.
 
     The paths in this list should contain files of the form `task.py`, for

--- a/python/lsst/obs/base/instrument.py
+++ b/python/lsst/obs/base/instrument.py
@@ -179,6 +179,26 @@ class Instrument(metaclass=ABCMeta):
             if os.path.exists(path):
                 config.load(path)
 
+    def writeCameraGeom(self, butler):
+        """Write the default camera geometry to the butler repository
+        with an infinite validity range.
+
+        Expected to be called from an instrument subclass
+        ``writeCuratedCalibrations`` implementation.
+
+        Parameters
+        ----------
+        butler : `lsst.daf.butler.Butler`
+            Butler to receive these calibration datasets.
+        """
+
+        datasetType = DatasetType("camera", ("instrument", "calibration_label"), "Camera",
+                                  universe=butler.registry.dimensions)
+        butler.registry.registerDatasetType(datasetType)
+        unboundedDataId = addUnboundedCalibrationLabel(butler.registry, self.getName())
+        camera = self.getCamera()
+        butler.put(camera, datasetType, unboundedDataId)
+
     def writeStandardTextCuratedCalibrations(self, butler):
         """Write the set of standardized curated text calibrations to
         the repository.

--- a/python/lsst/obs/base/instrument.py
+++ b/python/lsst/obs/base/instrument.py
@@ -30,7 +30,7 @@ from lsst.daf.butler import TIMESPAN_MIN, TIMESPAN_MAX, DatasetType, DataCoordin
 from lsst.utils import getPackageDir
 
 # To be a standard text curated calibration means that we use a
-# standard definition for the corresponding DatasetType
+# standard definition for the corresponding DatasetType.
 StandardCuratedCalibrationDatasetTypes = {
     "defects": {"dimensions": ("instrument", "detector", "calibration_label"),
                 "storageClass": "Defects"},
@@ -62,11 +62,13 @@ class Instrument(metaclass=ABCMeta):
     Usually a obs _data package.  If `None` no curated calibration files
     will be read. (`str`)"""
 
-    standardCuratedDatasetTypes = ("defects", "qe_curve")
+    standardCuratedDatasetTypes = tuple(StandardCuratedCalibrationDatasetTypes)
     """The dataset types expected to be obtained from the obsDataPackage.
     These dataset types are all required to have standard definitions and
     must be known to the base class.  Clearing this list will prevent
-    any of these calibrations from being stored.
+    any of these calibrations from being stored. If a dataset type is not
+    known to a specific instrument it can still be included in this list
+    since the data package is the source of truth.
     """
 
     @property


### PR DESCRIPTION
The code for reading defects and qe_curve datasets from data packages was the same in all obs packages so move it to the base class.