### PR TITLE
DM-24347: Allow WCS ingest test to be used for all obs types

### DIFF
--- a/python/lsst/obs/base/ingest_tests.py
+++ b/python/lsst/obs/base/ingest_tests.py
@@ -127,11 +127,8 @@ class IngestTestBase(metaclass=abc.ABCMeta):
             # Since components follow a different code path we check that
             # WCS match and also we check that at least the shape
             # of the image is the same (rather than doing per-pixel equality)
-            # Check the observation type before trying to check WCS
-            obsType = self.butler.registry.expandDataId(dataId).records["exposure"].observation_type
-            if obsType == "science":
-                wcs = self.butler.get("raw.wcs", dataId)
-                self.assertEqual(wcs, exposure.getWcs())
+            wcs = self.butler.get("raw.wcs", dataId)
+            self.assertEqual(wcs, exposure.getWcs())
 
             rawImage = self.butler.get("raw.image", dataId)
             self.assertEqual(rawImage.getBBox(), exposure.getBBox())


### PR DESCRIPTION
Previously butler would refuse to return a component
if it did not exist.