### PR TITLE
DM-24545: fix typo in register-instrument command name

### DIFF
--- a/python/lsst/obs/base/cli/cmd/register_instrument.py
+++ b/python/lsst/obs/base/cli/cmd/register_instrument.py
@@ -30,7 +30,7 @@ from ...utils import getInstrument
 log = logging.getLogger(__name__)
 
 
-@click.command("register_instrument")
+@click.command()
 @instrument_option(required=True, helpMsg="The fully-qualified name of an Instrument subclass.")
 @repo_option(required=True)
 @click.pass_context


### PR DESCRIPTION
The subcommand name comes from the function name, with the underscore
changed to a dash.

If named, the subcommand name should have had a dash ("register-instrument"),
but it didn't matter so much because Click was changing the underscore
to a dash with the explicitly provided command name anyway. But this
is more correct.