### PR TITLE
DM-24559 (pass butler registry to getInstrument) and DM-24683 (use PRODUCT_DIR instead of OBS_BASE_DIR)

### DIFF
--- a/python/lsst/obs/base/cli/butler_cmd_test.py
+++ b/python/lsst/obs/base/cli/butler_cmd_test.py
@@ -1,0 +1,59 @@
+# This file is part of obs_base.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Base class for writing CLI butler command tests.
+"""
+
+__all__ = ("ButlerCmdTestBase",)
+
+import abc
+import click
+import click.testing
+
+from lsst.daf.butler.cli import butler
+
+
+class ButlerCmdTestBase(metaclass=abc.ABCMeta):
+    """Base class for tests of butler command line interface subcommands.
+    Subclass from this, then `unittest.TestCase` to get a working test suite.
+    """
+
+    instrument_class = None
+    """The fully qualified instrument class.
+    """
+
+    instrument_name = None
+    """The instrument name."""
+
+    def test_cli(self):
+        runner = click.testing.CliRunner()
+        with runner.isolated_filesystem():
+            result = runner.invoke(butler.cli, ["create", "--repo", "here"])
+            self.assertEqual(result.exit_code, 0, result.output)
+            result = runner.invoke(butler.cli, ["register-instrument",
+                                                "--repo", "here",
+                                                "-i", self.instrument_class])
+            self.assertEqual(result.exit_code, 0, result.output)
+            result = runner.invoke(butler.cli, ["write-curated-calibrations",
+                                                "--repo", "here",
+                                                "-i", self.instrument_name,
+                                                "--output-run", "calib/hsc"])
+            self.assertEqual(result.exit_code, 0, result.output)

--- a/python/lsst/obs/base/cli/cmd/write_curated_calibrations.py
+++ b/python/lsst/obs/base/cli/cmd/write_curated_calibrations.py
@@ -40,7 +40,7 @@ def write_curated_calibrations(context, repo, instrument, output_run):
     """
     butler = Butler(repo, writeable=True, run=output_run)
     try:
-        instr = getInstrument(instrument)
+        instr = getInstrument(instrument, butler.registry)
     except RuntimeError as err:
         log.critical(f"Exception getting instrument: {err}")
         raise click.BadParameter(f"Failed getting instrument {instrument} from repo {repo}")

--- a/python/lsst/obs/base/cli/opt/instrument.py
+++ b/python/lsst/obs/base/cli/opt/instrument.py
@@ -26,7 +26,7 @@ import click
 class instrument_option:  # noqa: N801
     def __init__(self, required=False, helpMsg=None):
         self.required = required
-        self.help = helpMsg if helpMsg is not None else "The name of an Instrument subclass."
+        self.help = "The name or fully-qualified class name of an instrument." if helpMsg is None else helpMsg
 
     def __call__(self, f):
         return click.option("-i", "--instrument",

--- a/python/lsst/obs/base/utils.py
+++ b/python/lsst/obs/base/utils.py
@@ -108,8 +108,7 @@ def getInstrument(instrumentName, registry=None):
     Parameters
     ----------
     instrumentName : string
-        The name of an instrument, may be qualified with package names to look
-        in to import the instrument.
+        The name or fully-qualified class name of an instrument.
     registry : `lsst.daf.butler.Registry`, optional
         Butler registry to query to find information about the instrument, by
         default None

--- a/ups/obs_base.table
+++ b/ups/obs_base.table
@@ -11,4 +11,4 @@ setupOptional(skymap)
 
 envPrepend(PYTHONPATH, ${PRODUCT_DIR}/python)
 envPrepend(PATH, ${PRODUCT_DIR}/bin)
-envPrepend(DAF_BUTLER_PLUGINS, $OBS_BASE_DIR/python/lsst/obs/base/cli/resources.yaml)
+envPrepend(DAF_BUTLER_PLUGINS, ${PRODUCT_DIR}/python/lsst/obs/base/cli/resources.yaml)


### PR DESCRIPTION
DM-24683: Use PRODUCT_DIR instead of OBS_BASE_DIR in obs_base eups table file

DM-24559: write_curated_calibrations is not passing the butler registry to getInstrument