### PR TITLE
DM-24616: Do not try to open calib sqlite file if it does not exist

### DIFF
--- a/python/lsst/obs/base/cameraMapper.py
+++ b/python/lsst/obs/base/cameraMapper.py
@@ -668,9 +668,9 @@ class CameraMapper(dafPersist.Mapper):
             keyDict = self.mappings[datasetType].keys()
         if level is not None and level in self.levels:
             keyDict = copy.copy(keyDict)
-            for l in self.levels[level]:
-                if l in keyDict:
-                    del keyDict[l]
+            for lev in self.levels[level]:
+                if lev in keyDict:
+                    del keyDict[lev]
         return keyDict
 
     def getDefaultLevel(self):

--- a/python/lsst/obs/base/gen2to3/calibRepoConverter.py
+++ b/python/lsst/obs/base/gen2to3/calibRepoConverter.py
@@ -88,7 +88,16 @@ class CalibRepoConverter(RepoConverter):
         # This has only been tested on HSC, and it's not clear how general it
         # is.  The catch is that it needs to generate calibration_label strings
         # consistent with those produced by the Translator system.
-        db = sqlite3.connect(os.path.join(self.root, "calibRegistry.sqlite3"))
+
+        calibFile = os.path.join(self.root, "calibRegistry.sqlite3")
+
+        # If the registry file does not exist this indicates a problem.
+        # We check explicitly because sqlite will try to create the
+        # missing file if it can.
+        if not os.path.exists(calibFile):
+            raise RuntimeError("Attempting to convert calibrations but no registry database"
+                               f" found in {self.root}")
+        db = sqlite3.connect(calibFile)
         db.row_factory = sqlite3.Row
         records = []
         for datasetType in self._datasetTypes:

--- a/python/lsst/obs/base/gen2to3/convertTests.py
+++ b/python/lsst/obs/base/gen2to3/convertTests.py
@@ -47,7 +47,7 @@ class ConvertGen2To3TestCase:
     gen2root = ""
     """Root path to the gen2 repo to be converted."""
 
-    gen2calib = ""
+    gen2calib = None
     """Path to the gen2 calib repo to be converted."""
 
     instrumentName = None

--- a/python/lsst/obs/base/makeRawVisitInfo.py
+++ b/python/lsst/obs/base/makeRawVisitInfo.py
@@ -97,7 +97,7 @@ class MakeRawVisitInfo(object):
         self.setArgDict(md, argDict)
         for key in list(argDict.keys()):  # use a copy because we may delete items
             if argDict[key] is None:
-                self.log.warn("argDict[{}] is None; stripping".format(key, argDict[key]))
+                self.log.warn("argDict[%s] is None; stripping", key)
                 del argDict[key]
         return VisitInfo(**argDict)
 

--- a/python/lsst/obs/base/makeRawVisitInfoViaObsInfo.py
+++ b/python/lsst/obs/base/makeRawVisitInfoViaObsInfo.py
@@ -203,7 +203,7 @@ class MakeRawVisitInfoViaObsInfo(object):
         for key in list(argDict.keys()):  # use a copy because we may delete items
             if argDict[key] is None:
                 if log is not None:
-                    log.warn("argDict[{}] is None; stripping".format(key, argDict[key]))
+                    log.warn("argDict[%s] is None; stripping", key)
                 del argDict[key]
 
         return VisitInfo(**argDict)


### PR DESCRIPTION
Opening it causes sqlite3 to create the file.  This is rude but
also breaks when the input gen2 repo is read only.