### PR TITLE
DM-24260: Create Gen3 versions of ap_verify datasets

### DIFF
--- a/python/lsst/obs/base/gen2to3/rootRepoConverter.py
+++ b/python/lsst/obs/base/gen2to3/rootRepoConverter.py
@@ -78,8 +78,8 @@ class RootRepoConverter(StandardRepoConverter):
         if self.task.config.rootSkyMapName is not None:
             self._rootSkyMap = self.task.config.skyMaps[self.task.config.rootSkyMapName].skyMap.apply()
         else:
-            self._rootSkyMap = None
-        self._chain = None
+            self._rootSkyMap = None  # All access to _rootSkyMap is guarded
+        self._chain = {}
         self._rawRefs = []
 
     def isDatasetTypeSpecial(self, datasetTypeName: str) -> bool:


### PR DESCRIPTION
This PR partially fixes a bug where `RootRepoConverter` was initialized into an invalid state, and relied on later methods to become valid.