### PR TITLE
DM-24923: eliminate redundant class name & name requirement in butler command test cases

### DIFF
--- a/python/lsst/obs/base/ingest_tests.py
+++ b/python/lsst/obs/base/ingest_tests.py
@@ -56,7 +56,7 @@ class IngestTestBase(metaclass=abc.ABCMeta):
     file = ""
     """Full path to a file to ingest in tests."""
 
-    RawIngestTask = "lsst.obs.base.RawIngestTask"
+    rawIngestTask = "lsst.obs.base.RawIngestTask"
     """The task to use in the Ingest test."""
 
     curatedCalibrationDatasetTypes = None
@@ -145,22 +145,24 @@ class IngestTestBase(metaclass=abc.ABCMeta):
         pass
 
     def testLink(self):
-        ingestRaws(self.root, self.outputRun, file=self.file, transfer="link", ingest_task=self.RawIngestTask)
+        ingestRaws(self.root, self.outputRun, file=self.file, transfer="link",
+                   ingest_task=self.rawIngestTask)
         self.verifyIngest()
 
     def testSymLink(self):
         ingestRaws(self.root, self.outputRun, file=self.file, transfer="symlink",
-                   ingest_task=self.RawIngestTask)
+                   ingest_task=self.rawIngestTask)
         self.verifyIngest()
 
     def testCopy(self):
-        ingestRaws(self.root, self.outputRun, file=self.file, transfer="copy", ingest_task=self.RawIngestTask)
+        ingestRaws(self.root, self.outputRun, file=self.file, transfer="copy",
+                   ingest_task=self.rawIngestTask)
         self.verifyIngest()
 
     def testHardLink(self):
         try:
             ingestRaws(self.root, self.outputRun, file=self.file, transfer="hardlink",
-                       ingest_task=self.RawIngestTask)
+                       ingest_task=self.rawIngestTask)
             self.verifyIngest()
         except PermissionError as err:
             raise unittest.SkipTest("Skipping hard-link test because input data"
@@ -174,17 +176,17 @@ class IngestTestBase(metaclass=abc.ABCMeta):
         butler = Butler(self.root, run=self.outputRun)
         newPath = os.path.join(butler.datastore.root, os.path.basename(self.file))
         os.symlink(os.path.abspath(self.file), newPath)
-        ingestRaws(self.root, self.outputRun, file=newPath, transfer=None, ingest_task=self.RawIngestTask)
+        ingestRaws(self.root, self.outputRun, file=newPath, transfer=None, ingest_task=self.rawIngestTask)
         self.verifyIngest()
 
     def testFailOnConflict(self):
         """Re-ingesting the same data into the repository should fail.
         """
         ingestRaws(self.root, self.outputRun, file=self.file, transfer="symlink",
-                   ingest_task=self.RawIngestTask)
+                   ingest_task=self.rawIngestTask)
         with self.assertRaises(Exception):
             ingestRaws(self.root, self.outputRun, file=self.file, transfer="symlink",
-                       ingest_task=self.RawIngestTask)
+                       ingest_task=self.rawIngestTask)
 
     def testWriteCuratedCalibrations(self):
         """Test that we can ingest the curated calibrations"""
@@ -204,7 +206,8 @@ class IngestTestBase(metaclass=abc.ABCMeta):
     def testDefineVisits(self):
         if self.visits is None:
             self.skipTest("Expected visits were not defined.")
-        ingestRaws(self.root, self.outputRun, file=self.file, transfer="link", ingest_task=self.RawIngestTask)
+        ingestRaws(self.root, self.outputRun, file=self.file, transfer="link",
+                   ingest_task=self.rawIngestTask)
 
         config = self.DefineVisitsTask.ConfigClass()
         butler = Butler(self.root, run=self.outputRun)

--- a/python/lsst/obs/base/ingest_tests.py
+++ b/python/lsst/obs/base/ingest_tests.py
@@ -64,7 +64,7 @@ class IngestTestBase(metaclass=abc.ABCMeta):
     writeCuratedCalibrations. If `None` writeCuratedCalibrations will
     not be called and the test will be skipped."""
 
-    DefineVisitsTask = lsst.obs.base.DefineVisitsTask
+    defineVisitsTask = lsst.obs.base.DefineVisitsTask
     """The task to use to define visits from groups of exposures.
 
     This is ignored if ``visits`` is `None`.
@@ -209,11 +209,11 @@ class IngestTestBase(metaclass=abc.ABCMeta):
         ingestRaws(self.root, self.outputRun, file=self.file, transfer="link",
                    ingest_task=self.rawIngestTask)
 
-        config = self.DefineVisitsTask.ConfigClass()
+        config = self.defineVisitsTask.ConfigClass()
         butler = Butler(self.root, run=self.outputRun)
         instrument = getInstrument(self.instrumentName, butler.registry)
-        instrument.applyConfigOverrides(self.DefineVisitsTask._DefaultName, config)
-        task = self.DefineVisitsTask(config=config, butler=butler)
+        instrument.applyConfigOverrides(self.defineVisitsTask._DefaultName, config)
+        task = self.defineVisitsTask(config=config, butler=butler)
         task.run(self.dataIds)
 
         # Test that we got the visits we expected.

--- a/python/lsst/obs/base/ingest_tests.py
+++ b/python/lsst/obs/base/ingest_tests.py
@@ -92,7 +92,7 @@ class IngestTestBase(metaclass=abc.ABCMeta):
         pass
 
     @property
-    def instrument(self):
+    def instrumentClass(self):
         """The instrument class."""
         return doImport(self.instrumentClassName)
 
@@ -105,7 +105,7 @@ class IngestTestBase(metaclass=abc.ABCMeta):
         `str`
             The name of the instrument.
         """
-        return self.instrument.getName()
+        return self.instrumentClass.getName()
 
     def setUp(self):
         # Use a temporary working directory

--- a/python/lsst/obs/base/script/ingestRaws.py
+++ b/python/lsst/obs/base/script/ingestRaws.py
@@ -68,6 +68,7 @@ def ingestRaws(repo, output_run, config=None, config_file=None, directory=None, 
     ingester = TaskClass(config=ingestConfig, butler=butler)
     files = [file] if file is not None else []
     if directory is not None:
+        suffixes = (".fits", ".fits.gz", ".fits.fz")
         files.extend(
-            [os.path.join(directory, f) for f in os.listdir(directory) if f.lower().endswith("fits")])
+            [os.path.join(directory, f) for f in os.listdir(directory) if f.lower().endswith(suffixes)])
     ingester.run(files)


### PR DESCRIPTION
Class instance and instrument name can all be obtained from the
class name.

Use abstract property to ensure that the class name is provided.