### PR TITLE
DM-24830: Create dataset class for processed bright star stamps

### DIFF
--- a/policy/datasets.yaml
+++ b/policy/datasets.yaml
@@ -1540,3 +1540,11 @@ crosstalkCalib:
     storage: YamlStorage
     tables: raw
     template: ''
+brightStarStamps:
+    description: A set of processed postage stamps, each containing a single bright star.
+    persistable: BrightStarStamps
+    python: lsst.meas.algorithms.brightStarStamps.BrightStarStamps
+    storage: FitsStorage
+    level: Ccd
+    tables: raw
+    template:


### PR DESCRIPTION
One of 3 PRs for [DM-24830](https://jira.lsstcorp.org/browse/DM-24830) (the other two being obs_subaru and meas_algorithms).

This adds information about the new dataset so that the butler can put and get them.