### PR TITLE
DM-25080: Clean up usage of records argument to expandDataId.

### DIFF
--- a/python/lsst/obs/base/ingest.py
+++ b/python/lsst/obs/base/ingest.py
@@ -309,7 +309,7 @@ class RawIngestTask(Task):
             # records to be retrieved from the database here (though the
             # Registry may cache them so there isn't a lookup every time).
             records={
-                "exposure": data.record,
+                self.butler.registry.dimensions["exposure"]: data.record,
             }
         )
         # Now we expand the per-file (exposure+detector) data IDs.  This time


### PR DESCRIPTION
The key type accepted in this mapping was never very clear before, and we've now tightened it up to only accept DimensionElement instances, not str.