### PR TITLE
DM-25028 change butler create --config-file to --seed-config

### DIFF
--- a/tests/test_cliCmdDefineVisits.py
+++ b/tests/test_cliCmdDefineVisits.py
@@ -22,62 +22,43 @@
 """Unit tests for daf_butler CLI define-visits command.
 """
 
-import click
-import click.testing
 import unittest
 
-from lsst.daf.butler.cli import butler
-from lsst.daf.butler.cli.utils import Mocker, mockEnvVar
+from lsst.daf.butler.tests.mockeredTest import MockeredTestBase
 
 
-def makeExpectedKwargs(**kwargs):
-    expected = dict(config_file=None,
-                    collections=[])
-    expected.update(kwargs)
-    return expected
+class DefineVisitsTest(MockeredTestBase):
 
-
-class DefineVisitsTest(unittest.TestCase):
-
-    def run_test(self, inputs, expectedKwargs):
-        """Test command line interaction with the defineVisits command function.
-
-        Parameters
-        ----------
-        inputs : [`str`]
-            A list of the arguments to the butler command, starting with
-            `define-visits`
-        expectedKwargs : `dict` [`str`, `str`]
-            The expected arguments to the define-visits command function, keys are
-            the argument name and values are the argument value.
-        """
-        runner = click.testing.CliRunner(env=mockEnvVar)
-        result = runner.invoke(butler.cli, inputs)
-        self.assertEqual(result.exit_code, 0, f"output: {result.output} exception: {result.exception}")
-        Mocker.mock.assert_called_with(**expectedKwargs)
+    defaultExpected = dict(config_file=None,
+                           collections=[])
 
     def test_repoBasic(self):
         """Test the most basic required arguments."""
-        expected = makeExpectedKwargs(repo="here", instrument="a.b.c")
         self.run_test(["define-visits", "here",
-                       "--instrument", "a.b.c"], expected)
+                       "--instrument", "a.b.c"],
+                      self.makeExpected(repo="here",
+                                        instrument="a.b.c"))
 
     def test_all(self):
         """Test all the arguments."""
-        expected = dict(repo="here", instrument="a.b.c", config_file="/path/to/config",
-                        # The list of collections must be in exactly the same order as it is passed in the
-                        # list of arguments to run_test.
-                        collections=["foo/bar", "baz", "boz"])
         self.run_test(["define-visits", "here",
                        "--instrument", "a.b.c",
                        "--collections", "foo/bar,baz",
                        "--config-file", "/path/to/config",
-                       "--collections", "boz"], expected)
+                       "--collections", "boz"],
+                      self.makeExpected(repo="here",
+                                        instrument="a.b.c",
+                                        config_file="/path/to/config",
+                                        # The list of collections must be in
+                                        # exactly the same order as it is
+                                        # passed in the list of arguments to
+                                        # run_test.
+                                        collections=["foo/bar", "baz", "boz"]))
 
     def test_missing(self):
         """test a missing argument"""
-        with self.assertRaises(TypeError):
-            self.run_test(["define-visits", "from"])
+        self.run_missing(["define-visits"], 'Missing argument "REPO"')
+        self.run_missing(["define-visits", "here"], 'Missing option "-i" / "--instrument"')
 
 
 if __name__ == "__main__":

--- a/tests/test_cliCmdTestIngest.py
+++ b/tests/test_cliCmdTestIngest.py
@@ -19,81 +19,63 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Unit tests for daf_butler CLI config-dump command.
+"""Unit tests for daf_butler CLI ingest-raws command.
 """
 
-import click
-import click.testing
 import unittest
 
-from lsst.daf.butler.cli import butler
-from lsst.daf.butler.cli.utils import Mocker, mockEnvVar
+from lsst.daf.butler.tests.mockeredTest import MockeredTestBase
 
 
-def makeExpectedKwargs(**kwargs):
-    expected = dict(directory=None,
-                    file=None,
-                    transfer="auto",
-                    ingest_task="lsst.obs.base.RawIngestTask",
-                    config={},
-                    config_file=None)
-    expected.update(kwargs)
-    return expected
+class IngestRawsTestCase(MockeredTestBase):
 
-
-class Case(unittest.TestCase):
-
-    def run_test(self, inputs, expectedKwargs):
-        """Test command line interaction with ingest_raws command function.
-
-        Parameters
-        ----------
-        inputs : [`str`]
-            A list of the arguments to the butler command, starting with
-            `ingest-raws`
-        expectedKwargs : `dict` [`str`, `str`]
-            The expected arguments to the ingestRaws command function, keys are
-            the argument name and values are the argument value.
-        """
-        runner = click.testing.CliRunner(env=mockEnvVar)
-        result = runner.invoke(butler.cli, inputs)
-        self.assertEqual(result.exit_code, 0, f"output: {result.output} exception: {result.exception}")
-        Mocker.mock.assert_called_with(**expectedKwargs)
+    defaultExpected = dict(directory=None,
+                           file=None,
+                           transfer="auto",
+                           ingest_task="lsst.obs.base.RawIngestTask",
+                           config={},
+                           config_file=None)
 
     def test_repoAndOutput(self):
         """Test the most basic required arguments, repo and output run"""
-        expected = makeExpectedKwargs(repo="here", output_run="out")
         self.run_test(["ingest-raws", "here",
-                       "--output-run", "out"], expected)
+                       "--output-run", "out"],
+                      self.makeExpected(repo="here", output_run="out"))
 
     def test_configMulti(self):
         """Test config overrides"""
-        expected = makeExpectedKwargs(repo="here", output_run="out", config=dict(foo="1", bar="2", baz="3"))
         self.run_test(["ingest-raws", "here",
                        "--output-run", "out",
                        "-c", "foo=1",
-                       "--config", "bar=2,baz=3"], expected)
+                       "--config", "bar=2,baz=3"],
+                      self.makeExpected(repo="here",
+                                        output_run="out",
+                                        config=dict(foo="1", bar="2", baz="3")))
 
     def test_configFile(self):
         """Test config file override"""
-        expected = makeExpectedKwargs(repo="here", output_run="out", config_file="path/to/file.txt")
         self.run_test(["ingest-raws", "here",
                        "--output-run", "out",
-                       "--config-file", "path/to/file.txt"], expected)
+                       "--config-file", "path/to/file.txt"],
+                      self.makeExpected(repo="here",
+                                        output_run="out",
+                                        config_file="path/to/file.txt"))
 
     def test_transfer(self):
         """Test the transfer argument"""
-        expected = makeExpectedKwargs(repo="here", output_run="out", transfer="symlink")
         self.run_test(["ingest-raws", "here",
                        "--output-run", "out",
-                       "--transfer", "symlink"], expected)
+                       "--transfer", "symlink"],
+                      self.makeExpected(repo="here",
+                                        output_run="out",
+                                        transfer="symlink"))
 
     def test_ingestTask(self):
         """Test the ingest task argument"""
-        expected = makeExpectedKwargs(repo="here", output_run="out", ingest_task="foo.bar.baz")
         self.run_test(["ingest-raws", "here",
                        "--output-run", "out",
-                       "--ingest-task", "foo.bar.baz"], expected)
+                       "--ingest-task", "foo.bar.baz"],
+                      self.makeExpected(repo="here", output_run="out", ingest_task="foo.bar.baz"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This change doesn't actually have to do with changing config-file to seed-config, but I rewrote the command unit tests to have a common base class while I was doing this work.