### PR TITLE
DM-25458: Refactor raw/calib collection naming

### DIFF
--- a/python/lsst/obs/base/_instrument.py
+++ b/python/lsst/obs/base/_instrument.py
@@ -399,6 +399,27 @@ class Instrument(metaclass=ABCMeta):
         raise NotImplementedError("Must be implemented by derived classes.")
 
     @classmethod
+    def constructDefaultCollectionName(cls, label: str) -> str:
+        """Get the default instrument-specific collection string from the
+        supplied label.
+
+        Parameters
+        ----------
+        label : `str`
+            Generic type of collection from which to derive the default
+            name.  For example for ``raw`` this would return a string of the
+            form ``instrument_name/raw/all``.
+
+        Returns
+        -------
+        coll : `str`
+            Collection name to be used as the default for this generic label.
+        """
+        if label == "raw":
+            label = "raw/all"
+        return cls.constructCollectionName(label)
+
+    @classmethod
     def constructCollectionName(cls, label: str) -> str:
         """Get the instrument-specific collection string to use as derived
         from the supplied label.

--- a/python/lsst/obs/base/_instrument.py
+++ b/python/lsst/obs/base/_instrument.py
@@ -29,7 +29,15 @@ from typing import Any, Tuple, TYPE_CHECKING
 import astropy.time
 
 from lsst.afw.cameraGeom import Camera
-from lsst.daf.butler import Butler, DataId, TIMESPAN_MIN, TIMESPAN_MAX, DatasetType, DataCoordinate
+from lsst.daf.butler import (
+    Butler,
+    CollectionType,
+    DataCoordinate,
+    DataId,
+    DatasetType,
+    TIMESPAN_MIN,
+    TIMESPAN_MAX,
+)
 from lsst.utils import getPackageDir, doImport
 
 if TYPE_CHECKING:
@@ -236,7 +244,7 @@ class Instrument(metaclass=ABCMeta):
         """
         raise NotImplementedError()
 
-    def writeCuratedCalibrations(self, butler):
+    def writeCuratedCalibrations(self, butler, run=None):
         """Write human-curated calibration Datasets to the given Butler with
         the appropriate validity ranges.
 
@@ -244,14 +252,24 @@ class Instrument(metaclass=ABCMeta):
         ----------
         butler : `lsst.daf.butler.Butler`
             Butler to use to store these calibrations.
+        run : `str`
+            Run to use for this collection of calibrations. If `None` the
+            collection name is worked out automatically from the instrument
+            name and other metadata.
 
         Notes
         -----
         Expected to be called from subclasses.  The base method calls
         ``writeCameraGeom`` and ``writeStandardTextCuratedCalibrations``.
         """
-        self.writeCameraGeom(butler)
-        self.writeStandardTextCuratedCalibrations(butler)
+        # Need to determine the run for ingestion based on the instrument
+        # name and eventually the data package version. The camera geom
+        # is currently special in that it is not in the _data package.
+        if run is None:
+            run = self.constructCollectionName("calib")
+        butler.registry.registerCollection(run, type=CollectionType.RUN)
+        self.writeCameraGeom(butler, run=run)
+        self.writeStandardTextCuratedCalibrations(butler, run=run)
 
     def applyConfigOverrides(self, name, config):
         """Apply instrument-specific overrides for a task config.
@@ -269,7 +287,7 @@ class Instrument(metaclass=ABCMeta):
             if os.path.exists(path):
                 config.load(path)
 
-    def writeCameraGeom(self, butler):
+    def writeCameraGeom(self, butler, run=None):
         """Write the default camera geometry to the butler repository
         with an infinite validity range.
 
@@ -277,6 +295,9 @@ class Instrument(metaclass=ABCMeta):
         ----------
         butler : `lsst.daf.butler.Butler`
             Butler to receive these calibration datasets.
+        run : `str`, optional
+            Name of the run to use to override the default run associated
+            with this Butler.
         """
 
         datasetType = DatasetType("camera", ("instrument", "calibration_label"), "Camera",
@@ -284,9 +305,9 @@ class Instrument(metaclass=ABCMeta):
         butler.registry.registerDatasetType(datasetType)
         unboundedDataId = addUnboundedCalibrationLabel(butler.registry, self.getName())
         camera = self.getCamera()
-        butler.put(camera, datasetType, unboundedDataId)
+        butler.put(camera, datasetType, unboundedDataId, run=run)
 
-    def writeStandardTextCuratedCalibrations(self, butler):
+    def writeStandardTextCuratedCalibrations(self, butler, run=None):
         """Write the set of standardized curated text calibrations to
         the repository.
 
@@ -294,6 +315,9 @@ class Instrument(metaclass=ABCMeta):
         ----------
         butler : `lsst.daf.butler.Butler`
             Butler to receive these calibration datasets.
+        run : `str`, optional
+            Name of the run to use to override the default run associated
+            with this Butler.
         """
 
         for datasetTypeName in self.standardCuratedDatasetTypes:
@@ -305,9 +329,9 @@ class Instrument(metaclass=ABCMeta):
             datasetType = DatasetType(datasetTypeName,
                                       universe=butler.registry.dimensions,
                                       **definition)
-            self._writeSpecificCuratedCalibrationDatasets(butler, datasetType)
+            self._writeSpecificCuratedCalibrationDatasets(butler, datasetType, run=run)
 
-    def _writeSpecificCuratedCalibrationDatasets(self, butler, datasetType):
+    def _writeSpecificCuratedCalibrationDatasets(self, butler, datasetType, run=None):
         """Write standardized curated calibration datasets for this specific
         dataset type from an obs data package.
 
@@ -317,6 +341,9 @@ class Instrument(metaclass=ABCMeta):
             Gen3 butler in which to put the calibrations.
         datasetType : `lsst.daf.butler.DatasetType`
             Dataset type to be put.
+        run : `str`, optional
+            Name of the run to use to override the default run associated
+            with this Butler.
 
         Notes
         -----
@@ -378,7 +405,7 @@ class Instrument(metaclass=ABCMeta):
             # TODO: vectorize these puts, once butler APIs for that become
             # available.
             for calib, dataId in datasetRecords:
-                butler.put(calib, datasetType, dataId)
+                butler.put(calib, datasetType, dataId, run=run)
 
     @abstractmethod
     def makeDataIdTranslatorFactory(self) -> TranslatorFactory:

--- a/python/lsst/obs/base/_instrument.py
+++ b/python/lsst/obs/base/_instrument.py
@@ -270,6 +270,23 @@ class Instrument(metaclass=ABCMeta):
         butler.registry.registerCollection(run, type=CollectionType.RUN)
         self.writeCameraGeom(butler, run=run)
         self.writeStandardTextCuratedCalibrations(butler, run=run)
+        self.writeAdditionalCuratedCalibrations(butler, run=run)
+
+    def writeAdditionalCuratedCalibrations(self, butler, run=None):
+        """Write additional curated calibrations that might be instrument
+        specific and are not part of the standard set.
+
+        Default implementation does nothing.
+
+        Parameters
+        ----------
+        butler : `lsst.daf.butler.Butler`
+            Butler to use to store these calibrations.
+        run : `str`, optional
+            Name of the run to use to override the default run associated
+            with this Butler.
+        """
+        return
 
     def applyConfigOverrides(self, name, config):
         """Apply instrument-specific overrides for a task config.

--- a/python/lsst/obs/base/_instrument.py
+++ b/python/lsst/obs/base/_instrument.py
@@ -398,6 +398,24 @@ class Instrument(metaclass=ABCMeta):
         """
         raise NotImplementedError("Must be implemented by derived classes.")
 
+    @classmethod
+    def constructCollectionName(cls, label: str) -> str:
+        """Get the instrument-specific collection string to use as derived
+        from the supplied label.
+
+        Parameters
+        ----------
+        label : `str`
+            String to be combined with the instrument name to form a
+            collection name.
+
+        Returns
+        -------
+        name : `str`
+            Collection name to use that includes the instrument name.
+        """
+        return f"{cls.getName()}/{label}"
+
 
 def makeExposureRecordFromObsInfo(obsInfo, universe):
     """Construct an exposure DimensionRecord from

--- a/python/lsst/obs/base/_instrument.py
+++ b/python/lsst/obs/base/_instrument.py
@@ -266,7 +266,7 @@ class Instrument(metaclass=ABCMeta):
         # name and eventually the data package version. The camera geom
         # is currently special in that it is not in the _data package.
         if run is None:
-            run = self.constructCollectionName("calib")
+            run = self.makeCollectionName("calib")
         butler.registry.registerCollection(run, type=CollectionType.RUN)
         self.writeCameraGeom(butler, run=run)
         self.writeStandardTextCuratedCalibrations(butler, run=run)
@@ -443,28 +443,20 @@ class Instrument(metaclass=ABCMeta):
         raise NotImplementedError("Must be implemented by derived classes.")
 
     @classmethod
-    def constructDefaultCollectionName(cls, label: str) -> str:
-        """Get the default instrument-specific collection string from the
-        supplied label.
-
-        Parameters
-        ----------
-        label : `str`
-            Generic type of collection from which to derive the default
-            name.  For example for ``raw`` this would return a string of the
-            form ``instrument_name/raw/all``.
+    def makeDefaultRawIngestRunName(cls) -> str:
+        """Make the default instrument-specific run collection string for raw
+        data ingest.
 
         Returns
         -------
         coll : `str`
-            Collection name to be used as the default for this generic label.
+            Run collection name to be used as the default for ingestion of
+            raws.
         """
-        if label == "raw":
-            label = "raw/all"
-        return cls.constructCollectionName(label)
+        return cls.makeCollectionName("raw/all")
 
     @classmethod
-    def constructCollectionName(cls, label: str) -> str:
+    def makeCollectionName(cls, label: str) -> str:
         """Get the instrument-specific collection string to use as derived
         from the supplied label.
 

--- a/python/lsst/obs/base/cli/cmd/commands.py
+++ b/python/lsst/obs/base/cli/cmd/commands.py
@@ -72,7 +72,7 @@ def define_visits(*args, **kwargs):
 @repo_argument(required=True)
 @config_option()
 @config_file_option()
-@run_option(required=True)
+@run_option(required=False)
 @click.option("-d", "--dir", "directory",
               help="The path to the directory containing the raws to ingest.")
 @click.option("-f", "--file", help="The name of a file containing raws to ingest.")

--- a/python/lsst/obs/base/cli/cmd/commands.py
+++ b/python/lsst/obs/base/cli/cmd/commands.py
@@ -97,7 +97,7 @@ def register_instrument(*args, **kwargs):
 @click.command(short_help="Add an instrument's curated calibrations.")
 @repo_argument(required=True)
 @instrument_parameter(required=True)
-@run_option(required=True)
+@run_option(required=False)
 def write_curated_calibrations(*args, **kwargs):
     """Add an instrument's curated calibrations to the data repository.
     """

--- a/python/lsst/obs/base/gen2to3/convertTests.py
+++ b/python/lsst/obs/base/gen2to3/convertTests.py
@@ -141,7 +141,7 @@ class ConvertGen2To3TestCase(metaclass=abc.ABCMeta):
         self.gen3root = tempfile.mkdtemp()
         self.gen2Butler = lsst.daf.persistence.Butler(root=self.gen2root, calibRoot=self.gen2calib)
         self.collections = set(type(self).collections)
-        self.collections.add(self.instrumentClass.constructCollectionName("raw"))
+        self.collections.add(self.instrumentClass.constructDefaultCollectionName("raw"))
         if len(self.refcats) > 0:
             self.collections.add("refcats")
         if self.skymapName is not None:
@@ -269,8 +269,9 @@ class ConvertGen2To3TestCase(metaclass=abc.ABCMeta):
         """Test that all data are converted correctly.
         """
         self._run_convert()
+        instrument = self.instrumentClass
         gen3Butler = lsst.daf.butler.Butler(self.gen3root,
-                                            collections=self.instrumentClass.constructCollectionName("raw"))
+                                            collections=instrument.constructDefaultCollectionName("raw"))
         self.check_collections(gen3Butler)
 
         # check every raw detector that the gen2 butler knows about

--- a/python/lsst/obs/base/gen2to3/convertTests.py
+++ b/python/lsst/obs/base/gen2to3/convertTests.py
@@ -146,6 +146,8 @@ class ConvertGen2To3TestCase(metaclass=abc.ABCMeta):
             self.collections.add("refcats")
         if self.skymapName is not None:
             self.collections.add("skymaps")
+        if self.gen2calib:
+            self.collections.add(self.instrumentClass.constructCollectionName("calib"))
 
     def tearDown(self):
         shutil.rmtree(self.gen3root, ignore_errors=True)

--- a/python/lsst/obs/base/gen2to3/convertTests.py
+++ b/python/lsst/obs/base/gen2to3/convertTests.py
@@ -116,7 +116,7 @@ class ConvertGen2To3TestCase(metaclass=abc.ABCMeta):
     """Additional collections that should appear in the gen3 repo.
 
     This will automatically be populated by the base `setUp` to include
-    ``"raw/{instrumentName}"``, ``"refcats"`` (if the ``refcats``
+    ``"{instrumentName}/raw"``, ``"refcats"`` (if the ``refcats``
     class attribute is non-empty), and ``"skymaps"`` (if ``skymapName`` is
     not `None`).
     """
@@ -141,7 +141,7 @@ class ConvertGen2To3TestCase(metaclass=abc.ABCMeta):
         self.gen3root = tempfile.mkdtemp()
         self.gen2Butler = lsst.daf.persistence.Butler(root=self.gen2root, calibRoot=self.gen2calib)
         self.collections = set(type(self).collections)
-        self.collections.add(f"raw/{self.instrumentName}")
+        self.collections.add(self.instrumentClass.constructCollectionName("raw"))
         if len(self.refcats) > 0:
             self.collections.add("refcats")
         if self.skymapName is not None:
@@ -267,7 +267,8 @@ class ConvertGen2To3TestCase(metaclass=abc.ABCMeta):
         """Test that all data are converted correctly.
         """
         self._run_convert()
-        gen3Butler = lsst.daf.butler.Butler(self.gen3root, collections=f"raw/{self.instrumentName}")
+        gen3Butler = lsst.daf.butler.Butler(self.gen3root,
+                                            collections=self.instrumentClass.constructCollectionName("raw"))
         self.check_collections(gen3Butler)
 
         # check every raw detector that the gen2 butler knows about

--- a/python/lsst/obs/base/gen2to3/convertTests.py
+++ b/python/lsst/obs/base/gen2to3/convertTests.py
@@ -141,13 +141,13 @@ class ConvertGen2To3TestCase(metaclass=abc.ABCMeta):
         self.gen3root = tempfile.mkdtemp()
         self.gen2Butler = lsst.daf.persistence.Butler(root=self.gen2root, calibRoot=self.gen2calib)
         self.collections = set(type(self).collections)
-        self.collections.add(self.instrumentClass.constructDefaultCollectionName("raw"))
+        self.collections.add(self.instrumentClass.makeDefaultRawIngestRunName())
         if len(self.refcats) > 0:
             self.collections.add("refcats")
         if self.skymapName is not None:
             self.collections.add("skymaps")
         if self.gen2calib:
-            self.collections.add(self.instrumentClass.constructCollectionName("calib"))
+            self.collections.add(self.instrumentClass.makeCollectionName("calib"))
 
     def tearDown(self):
         shutil.rmtree(self.gen3root, ignore_errors=True)
@@ -269,9 +269,8 @@ class ConvertGen2To3TestCase(metaclass=abc.ABCMeta):
         """Test that all data are converted correctly.
         """
         self._run_convert()
-        instrument = self.instrumentClass
         gen3Butler = lsst.daf.butler.Butler(self.gen3root,
-                                            collections=instrument.constructDefaultCollectionName("raw"))
+                                            collections=self.instrumentClass.makeDefaultRawIngestRunName())
         self.check_collections(gen3Butler)
 
         # check every raw detector that the gen2 butler knows about

--- a/python/lsst/obs/base/ingest.py
+++ b/python/lsst/obs/base/ingest.py
@@ -462,7 +462,7 @@ class RawIngestTask(Task):
             # Override default run if nothing specified explicitly
             if run is None:
                 instrumentClass = exposure.files[0].instrumentClass
-                this_run = instrumentClass.constructCollectionName("raw")
+                this_run = instrumentClass.constructDefaultCollectionName("raw")
             else:
                 this_run = run
             if this_run not in runs:

--- a/python/lsst/obs/base/ingest.py
+++ b/python/lsst/obs/base/ingest.py
@@ -462,7 +462,7 @@ class RawIngestTask(Task):
             # Override default run if nothing specified explicitly
             if run is None:
                 instrumentClass = exposure.files[0].instrumentClass
-                this_run = instrumentClass.constructDefaultCollectionName("raw")
+                this_run = instrumentClass.makeDefaultRawIngestRunName()
             else:
                 this_run = run
             if this_run not in runs:

--- a/python/lsst/obs/base/script/convert.py
+++ b/python/lsst/obs/base/script/convert.py
@@ -92,10 +92,10 @@ def convert(repo, gen2root, instrument, skymap_name, skymap_config, calibs, reru
                            chainName=f"shared/{instr.getName()}", parents=[]) for rerun in reruns]
 
     # create a new butler instance for running the convert repo task
-    butler = lsst.daf.butler.Butler(butlerConfig, run=instr.constructDefaultCollectionName("raw"))
+    butler = lsst.daf.butler.Butler(butlerConfig, run=instr.makeDefaultRawIngestRunName())
     convertRepoTask = ConvertRepoTask(config=convertRepoConfig, butler3=butler)
     convertRepoTask.run(
         root=gen2root,
         reruns=rerunsArg,
-        calibs=None if calibs is None else {calibs: instr.constructCollectionName("calib")}
+        calibs=None if calibs is None else {calibs: instr.makeCollectionName("calib")}
     )

--- a/python/lsst/obs/base/script/convert.py
+++ b/python/lsst/obs/base/script/convert.py
@@ -92,7 +92,7 @@ def convert(repo, gen2root, instrument, skymap_name, skymap_config, calibs, reru
                            chainName=f"shared/{instr.getName()}", parents=[]) for rerun in reruns]
 
     # create a new butler instance for running the convert repo task
-    butler = lsst.daf.butler.Butler(butlerConfig, run=instr.constructCollectionName("raw"))
+    butler = lsst.daf.butler.Butler(butlerConfig, run=instr.constructDefaultCollectionName("raw"))
     convertRepoTask = ConvertRepoTask(config=convertRepoConfig, butler3=butler)
     convertRepoTask.run(
         root=gen2root,

--- a/python/lsst/obs/base/script/convert.py
+++ b/python/lsst/obs/base/script/convert.py
@@ -92,10 +92,10 @@ def convert(repo, gen2root, instrument, skymap_name, skymap_config, calibs, reru
                            chainName=f"shared/{instr.getName()}", parents=[]) for rerun in reruns]
 
     # create a new butler instance for running the convert repo task
-    butler = lsst.daf.butler.Butler(butlerConfig, run=f"raw/{instr.getName()}")
+    butler = lsst.daf.butler.Butler(butlerConfig, run=instr.constructCollectionName("raw"))
     convertRepoTask = ConvertRepoTask(config=convertRepoConfig, butler3=butler)
     convertRepoTask.run(
         root=gen2root,
         reruns=rerunsArg,
-        calibs=None if calibs is None else {calibs: f"calib/{instr.getName()}"}
+        calibs=None if calibs is None else {calibs: instr.constructCollectionName("calib")}
     )

--- a/python/lsst/obs/base/script/ingestRaws.py
+++ b/python/lsst/obs/base/script/ingestRaws.py
@@ -52,9 +52,10 @@ def ingestRaws(repo, output_run, config=None, config_file=None, directory=None, 
 
     Raises
     ------
-    `Exception` is raised if operations on configuration object fail.
+    Exception
+        Raised if operations on configuration object fail.
     """
-    butler = Butler(repo, run=output_run)
+    butler = Butler(repo, writeable=True)
     TaskClass = doImport(ingest_task)
     ingestConfig = TaskClass.ConfigClass()
     ingestConfig.transfer = transfer
@@ -71,4 +72,4 @@ def ingestRaws(repo, output_run, config=None, config_file=None, directory=None, 
         suffixes = (".fits", ".fits.gz", ".fits.fz")
         files.extend(
             [os.path.join(directory, f) for f in os.listdir(directory) if f.lower().endswith(suffixes)])
-    ingester.run(files)
+    ingester.run(files, run=output_run)

--- a/python/lsst/obs/base/script/writeCuratedCalibrations.py
+++ b/python/lsst/obs/base/script/writeCuratedCalibrations.py
@@ -35,18 +35,21 @@ def writeCuratedCalibrations(repo, instrument, output_run):
     repo : `str`
         URI to the location to create the repo.
     instrument : `str`
-        The name or the fully quallified class name of an instument.
+        The name or the fully qualified class name of an instrument.
     output_run : `str`
         The path to the location, the run, where datasets should be put.
+        Can be `None` in which case the collection name will be determined
+        automatically.
 
     Raises
     ------
     RuntimeError
-        If the instrument can not be imported, instantiated, or obtained from
-        the registry.
+        Raised if the instrument can not be imported, instantiated, or obtained
+        from the registry.
     TypeError
-        If the instrument is not a subclass of lsst.obs.base.Instrument.
+        Raised if the instrument is not a subclass of
+        `lsst.obs.base.Instrument`.
     """
-    butler = Butler(repo, writeable=True, run=output_run)
+    butler = Butler(repo, writeable=True)
     instr = getInstrument(instrument, butler.registry)
-    instr.writeCuratedCalibrations(butler)
+    instr.writeCuratedCalibrations(butler, run=output_run)

--- a/tests/test_cliCmdWriteCuratedCalibrations.py
+++ b/tests/test_cliCmdWriteCuratedCalibrations.py
@@ -47,8 +47,6 @@ class WriteCuratedCalibrationsTest(CliCmdTestBase, unittest.TestCase):
         """test a missing argument"""
         self.run_missing(["write-curated-calibrations"], 'Missing argument "REPO"')
         self.run_missing(["write-curated-calibrations", "here"], 'Missing option "-i" / "--instrument"')
-        self.run_missing(["write-curated-calibrations", "here", "-i", "a.b.c"],
-                         'Missing option "--output-run"')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
* Use single location for combining instrument name with collection label.
* No longer require the user to specify the output collection for ingest-raws and write-curated-calibrations.