### PR TITLE
DM-21915: Support Gen 3 ingestion of ap_verify datasets

### DIFF
--- a/python/lsst/obs/base/ingest.py
+++ b/python/lsst/obs/base/ingest.py
@@ -124,7 +124,7 @@ class RawExposureData:
         self.record = makeExposureRecordFromObsInfo(self.files[0].datasets[0].obsInfo, universe)
 
 
-def makeTransferChoiceField(doc="How to transfer files (None for no transfer).", default=None):
+def makeTransferChoiceField(doc="How to transfer files (None for no transfer).", default="auto"):
     """Create a Config field with options for how to transfer files between
     data repositories.
 


### PR DESCRIPTION
This PR changes the default transfer mode for `makeTransferChoiceField`, consistent with UI and API changes elsewhere.