### PR TITLE
DM-25923: Cache result from yamlCamera.makeCamera

### DIFF
--- a/python/lsst/obs/base/yamlCamera.py
+++ b/python/lsst/obs/base/yamlCamera.py
@@ -21,6 +21,7 @@
 
 import yaml
 
+from functools import lru_cache
 import numpy as np
 import lsst.afw.cameraGeom as cameraGeom
 import lsst.geom as geom
@@ -31,6 +32,7 @@ from lsst.afw.cameraGeom import Amplifier, Camera, ReadoutCorner
 __all__ = ["makeCamera"]
 
 
+@lru_cache()
 def makeCamera(cameraFile):
     """An imaging camera (e.g. the LSST 3Gpix camera)
 


### PR DESCRIPTION
Constructing a camera from YAML can take a long time (10 seconds for imsim) but the resulting object is immutable.  Caching can significantly speed up code that creates multiple cameras (in particular gen2 to 3 conversion code).