### PR TITLE
DM-26070: Add visit definition to ap_verify

### DIFF
--- a/python/lsst/obs/base/defineVisits.py
+++ b/python/lsst/obs/base/defineVisits.py
@@ -527,7 +527,7 @@ class _GroupExposuresByGroupMetadataTask(GroupExposuresTask, metaclass=ABCMeta):
     one-to-one algorithm for a particular camera in the same data repository.
     """
 
-    ConfigClass = _GroupExposuresOneToOneConfig
+    ConfigClass = _GroupExposuresByGroupMetadataConfig
 
     def group(self, exposures: List[DimensionRecord]) -> Iterable[VisitDefinitionData]:
         # Docstring inherited from GroupExposuresTask.


### PR DESCRIPTION
This PR fixes a cosmetic bug in how visit definition was being reported; previously, the program would always claim to be using one-to-one mapping.