### PR TITLE
DM-24575: Rewrite WCS calculation for define-visits

### DIFF
--- a/python/lsst/obs/base/_fitsRawFormatterBase.py
+++ b/python/lsst/obs/base/_fitsRawFormatterBase.py
@@ -33,7 +33,7 @@ import lsst.log
 
 from .formatters.fitsExposure import FitsExposureFormatter
 from .makeRawVisitInfoViaObsInfo import MakeRawVisitInfoViaObsInfo
-from .utils import createInitialSkyWcs, InitialSkyWcsError
+from .utils import createInitialSkyWcsFromBoresight, InitialSkyWcsError
 
 
 class FitsRawFormatterBase(FitsExposureFormatter, metaclass=ABCMeta):
@@ -231,9 +231,30 @@ class FitsRawFormatterBase(FitsExposureFormatter, metaclass=ABCMeta):
                 raise InitialSkyWcsError("Failed to create both metadata and boresight-based SkyWcs."
                                          "See warnings in log messages for details.")
             return skyWcs
-        skyWcs = createInitialSkyWcs(visitInfo, detector)
 
-        return skyWcs
+        return self.makeRawSkyWcsFromBoresight(visitInfo.getBoresightRaDec(),
+                                               visitInfo.getBoresightRotAngle(),
+                                               detector)
+
+    @classmethod
+    def makeRawSkyWcsFromBoresight(cls, boresight, orientation, detector):
+        """Class method to make a raw sky WCS from boresight and detector.
+
+        Parameters
+        ----------
+        boresight : `lsst.geom.SpherePoint`
+            The ICRS boresight RA/Dec
+        orientation : `lsst.geom.Angle`
+            The rotation angle of the focal plane on the sky.
+        detector : `lsst.afw.cameraGeom.Detector`
+            Where to get the camera geomtry from.
+
+        Returns
+        -------
+        skyWcs : `~lsst.afw.geom.SkyWcs`
+            Reversible mapping from pixel coordinates to sky coordinates.
+        """
+        return createInitialSkyWcsFromBoresight(boresight, orientation, detector)
 
     def _createSkyWcsFromMetadata(self):
         """Create a SkyWcs from the FITS header metadata in an Exposure.

--- a/python/lsst/obs/base/_instrument.py
+++ b/python/lsst/obs/base/_instrument.py
@@ -496,13 +496,15 @@ def makeExposureRecordFromObsInfo(obsInfo, universe):
     """
     dimension = universe["exposure"]
 
-    ra, dec, angle = (None, None, None)
+    ra, dec, sky_angle, zenith_angle = (None, None, None, None)
     if obsInfo.tracking_radec is not None:
         icrs = obsInfo.tracking_radec.icrs
         ra = icrs.ra.degree
         dec = icrs.dec.degree
         if obsInfo.boresight_rotation_coord == "sky":
-            angle = obsInfo.boresight_rotation_angle.degree
+            sky_angle = obsInfo.boresight_rotation_angle.degree
+    if obsInfo.altaz_begin is not None:
+        zenith_angle = obsInfo.altaz_begin.zen.degree
 
     return dimension.RecordClass.fromDict({
         "instrument": obsInfo.instrument,
@@ -520,7 +522,8 @@ def makeExposureRecordFromObsInfo(obsInfo, universe):
         "target_name": obsInfo.object,
         "tracking_ra": ra,
         "tracking_dec": dec,
-        "sky_angle": angle,
+        "sky_angle": sky_angle,
+        "zenith_angle": zenith_angle,
     })
 
 

--- a/python/lsst/obs/base/_instrument.py
+++ b/python/lsst/obs/base/_instrument.py
@@ -495,6 +495,15 @@ def makeExposureRecordFromObsInfo(obsInfo, universe):
         a `Registry`.
     """
     dimension = universe["exposure"]
+
+    ra, dec, angle = (None, None, None)
+    if obsInfo.tracking_radec is not None:
+        icrs = obsInfo.tracking_radec.icrs
+        ra = icrs.ra.degree
+        dec = icrs.dec.degree
+        if obsInfo.boresight_rotation_coord == "sky":
+            angle = obsInfo.boresight_rotation_angle.degree
+
     return dimension.RecordClass.fromDict({
         "instrument": obsInfo.instrument,
         "id": obsInfo.exposure_id,
@@ -507,6 +516,11 @@ def makeExposureRecordFromObsInfo(obsInfo, universe):
         "dark_time": obsInfo.dark_time.to_value("s"),
         "observation_type": obsInfo.observation_type,
         "physical_filter": obsInfo.physical_filter,
+        "science_program": obsInfo.science_program,
+        "target_name": obsInfo.object,
+        "tracking_ra": ra,
+        "tracking_dec": dec,
+        "sky_angle": angle,
     })
 
 

--- a/python/lsst/obs/base/defineVisits.py
+++ b/python/lsst/obs/base/defineVisits.py
@@ -328,6 +328,10 @@ class DefineVisitsTask(Task):
         exposure_time = _reduceOrNone(sum, (e.exposure_time for e in definition.exposures))
         physical_filter = _reduceOrNone(lambda a, b: a if a == b else None,
                                         (e.physical_filter for e in definition.exposures))
+        target_name = _reduceOrNone(lambda a, b: a if a == b else None,
+                                    (e.target_name for e in definition.exposures))
+        science_program = _reduceOrNone(lambda a, b: a if a == b else None,
+                                        (e.science_program for e in definition.exposures))
         # Construct the actual DimensionRecords.
         return _VisitRecords(
             visit=self.universe["visit"].RecordClass.fromDict({
@@ -335,6 +339,8 @@ class DefineVisitsTask(Task):
                 "id": definition.id,
                 "name": definition.name,
                 "physical_filter": physical_filter,
+                "target_name": target_name,
+                "science_program": science_program,
                 "visit_system": self.groupExposures.getVisitSystem()[0],
                 "exposure_time": exposure_time,
                 TIMESPAN_FIELD_SPECS.begin.name: timespan.begin,

--- a/python/lsst/obs/base/defineVisits.py
+++ b/python/lsst/obs/base/defineVisits.py
@@ -656,7 +656,7 @@ class _ComputeVisitRegionsFromSingleRawWcsTask(ComputeVisitRegionsTask):
                 for detectorId, bounds in exposureDetectorBounds.items():
                     detectorBounds[detectorId].extend(bounds)
         else:
-            detectorBounds = self.computeExposureBounds(visit.exposures[0])
+            detectorBounds = self.computeExposureBounds(visit.exposures[0], collections=collections)
         visitBounds = []
         detectorRegions = {}
         for detectorId, bounds in detectorBounds.items():

--- a/python/lsst/obs/base/defineVisits.py
+++ b/python/lsst/obs/base/defineVisits.py
@@ -362,6 +362,12 @@ class DefineVisitsTask(Task):
                                     (e.target_name for e in definition.exposures))
         science_program = _reduceOrNone(lambda a, b: a if a == b else None,
                                         (e.science_program for e in definition.exposures))
+
+        # Use the mean zenith angle as an approximation
+        zenith_angle = _reduceOrNone(sum, (e.zenith_angle for e in definition.exposures))
+        if zenith_angle is not None:
+            zenith_angle /= len(definition.exposures)
+
         # Construct the actual DimensionRecords.
         return _VisitRecords(
             visit=self.universe["visit"].RecordClass.fromDict({
@@ -371,6 +377,7 @@ class DefineVisitsTask(Task):
                 "physical_filter": physical_filter,
                 "target_name": target_name,
                 "science_program": science_program,
+                "zenith_angle": zenith_angle,
                 "visit_system": self.groupExposures.getVisitSystem()[0],
                 "exposure_time": exposure_time,
                 TIMESPAN_FIELD_SPECS.begin.name: timespan.begin,

--- a/python/lsst/obs/base/script/defineVisits.py
+++ b/python/lsst/obs/base/script/defineVisits.py
@@ -40,9 +40,12 @@ def defineVisits(repo, config_file, collections, instrument):
     collections : `list` [`str`]
         An expression specifying the collections to be searched (in order) when
         reading datasets, and optionally dataset type restrictions on them.
+        If empty it will be passed as `None` to Butler.
     insrument : `str`
         The name or fully-qualified class name of an instrument.
     """
+    if not collections:
+        collections = None
     butler = Butler(repo, collections=collections, writeable=True)
     instr = getInstrument(instrument, butler.registry)
     config = DefineVisitsConfig()

--- a/python/lsst/obs/base/script/defineVisits.py
+++ b/python/lsst/obs/base/script/defineVisits.py
@@ -51,7 +51,12 @@ def defineVisits(repo, config_file, collections, instrument):
     config = DefineVisitsConfig()
     instr.applyConfigOverrides(DefineVisitsTask._DefaultName, config)
 
+    if collections is None:
+        # Default to the raw collection for this instrument
+        collections = instr.makeDefaultRawIngestRunName()
+
     if config_file is not None:
         config.load(config_file)
     task = DefineVisitsTask(config=config, butler=butler)
-    task.run(butler.registry.queryDataIds(["exposure"]))
+    task.run(butler.registry.queryDataIds(["exposure"], dataId={"instrument": instr.getName()}),
+             collections=collections)


### PR DESCRIPTION
Uses information from registry rather than retrieving a dataset from the datastore.

Depends on lsst/daf_butler#350