### PR TITLE
DM-26082: Persist source-to-external reference matched catalogs in pipe_analysis to parquet

### DIFF
--- a/policy/datasets.yaml
+++ b/policy/datasets.yaml
@@ -1333,6 +1333,16 @@ analysisVisitTable_commonZp:
     storage: ParquetStorage
     python: lsst.pipe.tasks.parquetTable.ParquetTable
     template: plots/%(filter)s/tract-%(tract)d/visit-%(visit)d%(subdir)s/%(tract)d_%(visit)d_commonZp.parq
+analysisMatchFullRefVisitTable:
+    description: >
+        Per-visit table (for specific tract) of the matched source-to-external reference
+        catalog assembled by pipe_analysis scripts.  The table is "denormalized", i.e.
+        contains all fields from the original source and external catalogs (but with
+        "src_" and "ref_" prefixes on the column names).
+    persistable: ignored
+    storage: ParquetStorage
+    python: lsst.pipe.tasks.parquetTable.ParquetTable
+    template: plots/%(filter)s/tract-%(tract)d/visit-%(visit)d%(subdir)s/%(tract)d_%(visit)d_matchFullRef.parq
 analysisCoaddTable_forced:
     description: >
         Per-tract object table assembled by pipe_analysis scripts (forced photometry).
@@ -1347,6 +1357,26 @@ analysisCoaddTable_unforced:
     storage: ParquetStorage
     python: lsst.pipe.tasks.parquetTable.ParquetTable
     template: plots/%(filter)s/tract-%(tract)d%(subdir)s/%(tract)d_unforced.parq
+analysisMatchFullRefCoaddTable_forced:
+    description: >
+        Per-tract table of the matched source-to-external reference catalog assembled
+        by pipe_analysis scripts (forced photometry).  The table is "denormalized", i.e.
+        contains all fields from the original source and external catalogs (but with
+        "src_" and "ref_" prefixes on the column names).
+    persistable: ignored
+    storage: ParquetStorage
+    python: lsst.pipe.tasks.parquetTable.ParquetTable
+    template: plots/%(filter)s/tract-%(tract)d%(subdir)s/%(tract)d_matchFullRef_forced.parq
+analysisMatchFullRefCoaddTable_unforced:
+    description: >
+        Per-tract table of the matched source-to-external reference catalog assembled
+        by pipe_analysis scripts (unforced photometry).  The table is "denormalized", i.e.
+        contains all fields from the original source and external catalogs (but with
+        "src_" and "ref_" prefixes on the column names).
+    persistable: ignored
+    storage: ParquetStorage
+    python: lsst.pipe.tasks.parquetTable.ParquetTable
+    template: plots/%(filter)s/tract-%(tract)d%(subdir)s/%(tract)d_matchFullRef_unforced.parq
 analysisColorTable:
     description: >
         Principal color table assembled by pipe_analysis scripts.


### PR DESCRIPTION
The scripts in pipe_analysis perform a matching between sources and
external reference catalogs (those used in the calibration stages) to
create comparison plots.  This adds datasets to persist those matched
catalogs at the tract/visit level (although any sub-selection of
patch/ccd can be made for a given run) to parquet tables for use in
further QA/validation pursuits.