### PR TITLE
DM-26671: Support click 7.0 and 7.1 in unit tests

### DIFF
--- a/tests/test_cliCmdConvert.py
+++ b/tests/test_cliCmdConvert.py
@@ -72,8 +72,8 @@ class ConvertTestCase(CliCmdTestBase, unittest.TestCase):
 
     def test_missing(self):
         """test a missing argument"""
-        self.run_missing(["convert"], 'Missing argument "REPO"')
-        self.run_missing(["convert", "here"], 'Missing option "--gen2root"')
+        self.run_missing(["convert"], "Missing argument ['\"]REPO['\"]")
+        self.run_missing(["convert", "here"], "Missing option ['\"]--gen2root['\"]")
 
 
 if __name__ == "__main__":

--- a/tests/test_cliCmdDefineVisits.py
+++ b/tests/test_cliCmdDefineVisits.py
@@ -64,8 +64,8 @@ class DefineVisitsTest(CliCmdTestBase, unittest.TestCase):
 
     def test_missing(self):
         """test a missing argument"""
-        self.run_missing(["define-visits"], 'Missing argument "REPO"')
-        self.run_missing(["define-visits", "here"], 'Missing option "-i" / "--instrument"')
+        self.run_missing(["define-visits"], "Missing argument ['\"]REPO['\"]")
+        self.run_missing(["define-visits", "here"], "Missing option ['\"]-i['\"] / ['\"]--instrument['\"]")
 
 
 if __name__ == "__main__":

--- a/tests/test_cliCmdRegisterInstrument.py
+++ b/tests/test_cliCmdRegisterInstrument.py
@@ -46,8 +46,8 @@ class RegisterInstrumentTest(CliCmdTestBase, unittest.TestCase):
 
     def test_missing(self):
         """test a missing argument"""
-        self.run_missing(["register-instrument"], 'Missing argument "REPO"')
-        self.run_missing(["register-instrument", "here"], 'Missing argument "INSTRUMENT ..."')
+        self.run_missing(["register-instrument"], "Missing argument ['\"]REPO['\"]")
+        self.run_missing(["register-instrument", "here"], "Missing argument ['\"]INSTRUMENT ...['\"]")
 
 
 if __name__ == "__main__":

--- a/tests/test_cliCmdWriteCuratedCalibrations.py
+++ b/tests/test_cliCmdWriteCuratedCalibrations.py
@@ -50,7 +50,9 @@ class WriteCuratedCalibrationsTest(CliCmdTestBase, unittest.TestCase):
     def test_missing(self):
         """test a missing argument"""
         self.run_missing(["write-curated-calibrations"], "Missing argument ['\"]REPO['\"]")
-        self.run_missing(["write-curated-calibrations", "here"], "Missing option ['\"]-i['\"] / ['\"]--instrument['\"]")
+        self.run_missing(
+            ["write-curated-calibrations", "here"], "Missing option ['\"]-i['\"] / ['\"]--instrument['\"]"
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_cliCmdWriteCuratedCalibrations.py
+++ b/tests/test_cliCmdWriteCuratedCalibrations.py
@@ -49,8 +49,8 @@ class WriteCuratedCalibrationsTest(CliCmdTestBase, unittest.TestCase):
 
     def test_missing(self):
         """test a missing argument"""
-        self.run_missing(["write-curated-calibrations"], 'Missing argument "REPO"')
-        self.run_missing(["write-curated-calibrations", "here"], 'Missing option "-i" / "--instrument"')
+        self.run_missing(["write-curated-calibrations"], "Missing argument ['\"]REPO['\"]")
+        self.run_missing(["write-curated-calibrations", "here"], "Missing option ['\"]-i['\"] / ['\"]--instrument['\"]")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This change modifies the regex to be accepting of both single quote and double quote in click-generated error messages. Click 7.1 switched from double quotes to single quotes.