### PR TITLE
DM-27097: Enable -j for butler convert

### DIFF
--- a/python/lsst/obs/base/cli/cmd/commands.py
+++ b/python/lsst/obs/base/cli/cmd/commands.py
@@ -55,6 +55,7 @@ fits_re = r"\.fit[s]?\b"
 @click.option("--reruns", multiple=True, callback=split_commas, metavar=typeStrAcceptsMultiple,
               help="List of gen 2 reruns to convert.")
 @transfer_option(help="Mode to use to transfer files into the new repository.")
+@processes_option()
 @config_file_option(help="Path to a `ConvertRepoConfig` override to be included after the Instrument config "
                     "overrides are applied.")
 @options_file_option()
@@ -73,6 +74,7 @@ def convert(*args, **kwargs):
               multiple=True,
               callback=split_commas,
               metavar=typeStrAcceptsMultiple)
+@processes_option()
 @options_file_option()
 def define_visits(*args, **kwargs):
     """Define visits from exposures in the butler registry."""

--- a/python/lsst/obs/base/gen2to3/convertRepo.py
+++ b/python/lsst/obs/base/gen2to3/convertRepo.py
@@ -444,7 +444,8 @@ class ConvertRepoTask(Task):
     def run(self, root: str, *,
             calibs: Dict[str, str] = None,
             reruns: List[Rerun],
-            visits: Optional[Iterable[int]] = None):
+            visits: Optional[Iterable[int]] = None,
+            processes: int = 1):
         """Convert a group of related data repositories.
 
         Parameters
@@ -463,6 +464,8 @@ class ConvertRepoTask(Task):
         visits : iterable of `int`, optional
             The integer IDs of visits to convert.  If not provided, all visits
             in the Gen2 root repository will be converted.
+        processes : `int`, optional
+            The number of processes to use for conversion.
         """
         if calibs is None:
             calibs = {}
@@ -507,7 +510,7 @@ class ConvertRepoTask(Task):
 
         # Run raw ingest (does nothing if we weren't configured to convert the
         # 'raw' dataset type).
-        rootConverter.runRawIngest()
+        rootConverter.runRawIngest(processes=processes)
 
         # Write curated calibrations to all calibration runs and
         # also in the default collection.
@@ -536,7 +539,7 @@ class ConvertRepoTask(Task):
 
         # Define visits (also does nothing if we weren't configurd to convert
         # the 'raw' dataset type).
-        rootConverter.runDefineVisits()
+        rootConverter.runDefineVisits(processes=processes)
 
         # Walk Gen2 repos to find datasets convert.
         for converter in converters:

--- a/python/lsst/obs/base/gen2to3/rootRepoConverter.py
+++ b/python/lsst/obs/base/gen2to3/rootRepoConverter.py
@@ -106,7 +106,7 @@ class RootRepoConverter(StandardRepoConverter):
             name = self.task.config.rootSkyMapName
         return skyMap, name
 
-    def runRawIngest(self):
+    def runRawIngest(self, processes=1):
         if self.task.raws is None:
             return
         self.task.log.info(f"Finding raws in root {self.root}.")
@@ -119,16 +119,16 @@ class RootRepoConverter(StandardRepoConverter):
             dataRefs = self.butler2.subset(self.task.config.rawDatasetType)
         dataPaths = getDataPaths(dataRefs)
         self.task.log.info("Ingesting raws from root %s into run %s.", self.root, self.task.raws.butler.run)
-        self._rawRefs.extend(self.task.raws.run(dataPaths))
+        self._rawRefs.extend(self.task.raws.run(dataPaths, processes=processes))
         self._chain = {self.task.raws.butler.run: {self.task.raws.datasetType.name}}
 
-    def runDefineVisits(self):
+    def runDefineVisits(self, processes=1):
         if self.task.defineVisits is None:
             return
         dimensions = DimensionGraph(self.task.universe, names=["exposure"])
         exposureDataIds = set(ref.dataId.subset(dimensions) for ref in self._rawRefs)
         self.task.log.info("Defining visits from exposures.")
-        self.task.defineVisits.run(exposureDataIds)
+        self.task.defineVisits.run(exposureDataIds, processes=processes)
 
     def prep(self):
         # Docstring inherited from RepoConverter.

--- a/python/lsst/obs/base/gen2to3/rootRepoConverter.py
+++ b/python/lsst/obs/base/gen2to3/rootRepoConverter.py
@@ -106,7 +106,7 @@ class RootRepoConverter(StandardRepoConverter):
             name = self.task.config.rootSkyMapName
         return skyMap, name
 
-    def runRawIngest(self, processes=1):
+    def runRawIngest(self, pool=None):
         if self.task.raws is None:
             return
         self.task.log.info(f"Finding raws in root {self.root}.")
@@ -119,16 +119,16 @@ class RootRepoConverter(StandardRepoConverter):
             dataRefs = self.butler2.subset(self.task.config.rawDatasetType)
         dataPaths = getDataPaths(dataRefs)
         self.task.log.info("Ingesting raws from root %s into run %s.", self.root, self.task.raws.butler.run)
-        self._rawRefs.extend(self.task.raws.run(dataPaths, processes=processes))
+        self._rawRefs.extend(self.task.raws.run(dataPaths, pool=pool))
         self._chain = {self.task.raws.butler.run: {self.task.raws.datasetType.name}}
 
-    def runDefineVisits(self, processes=1):
+    def runDefineVisits(self, pool=None):
         if self.task.defineVisits is None:
             return
         dimensions = DimensionGraph(self.task.universe, names=["exposure"])
         exposureDataIds = set(ref.dataId.subset(dimensions) for ref in self._rawRefs)
         self.task.log.info("Defining visits from exposures.")
-        self.task.defineVisits.run(exposureDataIds, processes=processes)
+        self.task.defineVisits.run(exposureDataIds, pool=pool)
 
     def prep(self):
         # Docstring inherited from RepoConverter.

--- a/python/lsst/obs/base/script/convert.py
+++ b/python/lsst/obs/base/script/convert.py
@@ -32,7 +32,7 @@ from lsst.log.utils import temporaryLogLevel
 from ..gen2to3 import ConvertRepoTask, ConvertRepoSkyMapConfig, Rerun
 
 
-def convert(repo, gen2root, skymap_name, skymap_config, calibs, reruns, config_file, transfer):
+def convert(repo, gen2root, skymap_name, skymap_config, calibs, reruns, config_file, transfer, processes=1):
     """Implements the command line interface `butler convert` subcommand,
     should only be called by command line tools and unit test code that tests
     this function.
@@ -62,6 +62,8 @@ def convert(repo, gen2root, skymap_name, skymap_config, calibs, reruns, config_f
         after all default/instrument configurations.
     transfer : `str` or None
         Mode to use when transferring data into the gen3 repository.
+    processess : `int`
+        Number of processes to use for conversion.
     """
     # Allow a gen3 butler to be reused
     try:
@@ -104,5 +106,6 @@ def convert(repo, gen2root, skymap_name, skymap_config, calibs, reruns, config_f
     convertRepoTask.run(
         root=gen2root,
         reruns=rerunsArg,
-        calibs=None if calibs is None else {calibs: instrument.makeCollectionName("calib")}
+        calibs=None if calibs is None else {calibs: instrument.makeCollectionName("calib")},
+        processes=processes,
     )

--- a/python/lsst/obs/base/script/defineVisits.py
+++ b/python/lsst/obs/base/script/defineVisits.py
@@ -24,7 +24,7 @@ from lsst.obs.base import DefineVisitsTask, DefineVisitsConfig
 from ..utils import getInstrument
 
 
-def defineVisits(repo, config_file, collections, instrument):
+def defineVisits(repo, config_file, collections, instrument, processes=1):
     """Implements the command line interface `butler define-visits` subcommand,
     should only be called by command line tools and unit test code that tests
     this function.
@@ -59,4 +59,4 @@ def defineVisits(repo, config_file, collections, instrument):
         config.load(config_file)
     task = DefineVisitsTask(config=config, butler=butler)
     task.run(butler.registry.queryDataIds(["exposure"], dataId={"instrument": instr.getName()}),
-             collections=collections)
+             collections=collections, processes=processes)

--- a/tests/test_cliCmdConvert.py
+++ b/tests/test_cliCmdConvert.py
@@ -37,6 +37,7 @@ class ConvertTestCase(CliCmdTestBase, unittest.TestCase):
                     calibs=None,
                     reruns=(),
                     transfer="auto",
+                    processes=1,
                     config_file=None)
 
     @staticmethod
@@ -60,6 +61,7 @@ class ConvertTestCase(CliCmdTestBase, unittest.TestCase):
                        "--reruns", "one,two",
                        "--reruns", "three",
                        "--transfer", "symlink",
+                       "--processes", 1,
                        "--config-file", "/path/to/config"],
                       self.makeExpected(repo="here",
                                         gen2root="from",
@@ -68,6 +70,7 @@ class ConvertTestCase(CliCmdTestBase, unittest.TestCase):
                                         calibs="path/to/calib/repo",
                                         reruns=("one", "two", "three"),
                                         transfer="symlink",
+                                        processes=1,
                                         config_file="/path/to/config"))
 
     def test_missing(self):

--- a/tests/test_cliCmdDefineVisits.py
+++ b/tests/test_cliCmdDefineVisits.py
@@ -43,6 +43,7 @@ class DefineVisitsTest(CliCmdTestBase, unittest.TestCase):
         """Test the most basic required arguments."""
         self.run_test(["define-visits", "here", "a.b.c"],
                       self.makeExpected(repo="here",
+                                        processes=1,
                                         instrument="a.b.c"))
 
     def test_all(self):
@@ -50,10 +51,12 @@ class DefineVisitsTest(CliCmdTestBase, unittest.TestCase):
         self.run_test(["define-visits", "here", "a.b.c",
                        "--collections", "foo/bar,baz",
                        "--config-file", "/path/to/config",
+                       "--processes", 2,
                        "--collections", "boz"],
                       self.makeExpected(repo="here",
                                         instrument="a.b.c",
                                         config_file="/path/to/config",
+                                        processes=2,
                                         # The list of collections must be in
                                         # exactly the same order as it is
                                         # passed in the list of arguments to


### PR DESCRIPTION
The ingest-raws and define-visits already support -j so this is mostly pushing the parameter down.