### PR TITLE
DM-27350: Define mandatory properties for ObservationInfo

### DIFF
--- a/python/lsst/obs/base/_instrument.py
+++ b/python/lsst/obs/base/_instrument.py
@@ -738,7 +738,8 @@ def makeExposureRecordFromObsInfo(obsInfo, universe):
         datetime_begin=obsInfo.datetime_begin,
         datetime_end=obsInfo.datetime_end,
         exposure_time=obsInfo.exposure_time.to_value("s"),
-        dark_time=obsInfo.dark_time.to_value("s"),
+        # we are not mandating that dark_time be calculable
+        dark_time=obsInfo.dark_time.to_value("s") if obsInfo.dark_time is not None else None,
         observation_type=obsInfo.observation_type,
         observation_reason=obsInfo.observation_reason,
         physical_filter=obsInfo.physical_filter,

--- a/python/lsst/obs/base/ingest.py
+++ b/python/lsst/obs/base/ingest.py
@@ -279,7 +279,38 @@ class RawIngestTask(Task):
             The dataId, and observation information associated with this
             dataset.
         """
-        obsInfo = ObservationInfo(header)
+        # To ensure we aren't slowed down for no reason, explicitly
+        # list here the properties we need for the schema
+        # Use a dict with values a boolean where True indicates
+        # that it is required that we calculate this property.
+        ingest_subset = {
+            "altaz_begin": False,
+            "boresight_rotation_coord": False,
+            "boresight_rotation_angle": False,
+            "dark_time": False,
+            "datetime_begin": True,
+            "datetime_end": True,
+            "detector_num": True,
+            "exposure_group": False,
+            "exposure_id": True,
+            "exposure_time": True,
+            "instrument": True,
+            "tracking_radec": False,
+            "object": False,
+            "observation_counter": False,
+            "observation_id": True,
+            "observation_reason": False,
+            "observation_type": True,
+            "observing_day": False,
+            "physical_filter": True,
+            "science_program": False,
+            "visit_id": False,
+        }
+
+        obsInfo = ObservationInfo(header, pedantic=False,
+                                  required={k for k in ingest_subset if ingest_subset[k]},
+                                  subset=set(ingest_subset))
+
         dataId = DataCoordinate.standardize(instrument=obsInfo.instrument,
                                             exposure=obsInfo.exposure_id,
                                             detector=obsInfo.detector_num,


### PR DESCRIPTION
* Declare up front that things like instrument and exposure_id must be calculable.
* Tell ObservationInfo only to calculate properties used by registry.  This can speed things up a little, although we are using most of the properties by this point.

Depends on lsst/astro_metadata_translator#42