### PR TITLE
DM-26696: Pass filename to ObservationInfo for ingest logging

### DIFF
--- a/python/lsst/obs/base/_fitsRawFormatterBase.py
+++ b/python/lsst/obs/base/_fitsRawFormatterBase.py
@@ -368,7 +368,7 @@ class FitsRawFormatterBase(FitsExposureFormatter, metaclass=ABCMeta):
     def readRawHeaderWcs(self, parameters=None):
         """Read the SkyWcs stored in the un-modified raw FITS WCS header keys.
         """
-        return lsst.afw.geom.makeSkyWcs(lsst.afw.fits.readMetadata(self.fileDescriptor))
+        return lsst.afw.geom.makeSkyWcs(lsst.afw.fits.readMetadata(self.fileDescriptor.location.path))
 
     def write(self, inMemoryDataset):
         """Write a Python object to a file.

--- a/python/lsst/obs/base/_fitsRawFormatterBase.py
+++ b/python/lsst/obs/base/_fitsRawFormatterBase.py
@@ -392,5 +392,8 @@ class FitsRawFormatterBase(FitsExposureFormatter, metaclass=ABCMeta):
         read-only).
         """
         if self._observationInfo is None:
-            self._observationInfo = ObservationInfo(self.metadata, translator_class=self.translatorClass)
+            location = self.fileDescriptor.location
+            path = location.path if location is not None else None
+            self._observationInfo = ObservationInfo(self.metadata, translator_class=self.translatorClass,
+                                                    filename=path)
         return self._observationInfo

--- a/python/lsst/obs/base/ingest.py
+++ b/python/lsst/obs/base/ingest.py
@@ -306,7 +306,7 @@ class RawIngestTask(Task):
             "visit_id": False,
         }
 
-        obsInfo = ObservationInfo(header, pedantic=False,
+        obsInfo = ObservationInfo(header, pedantic=False, filename=filename,
                                   required={k for k in ingest_subset if ingest_subset[k]},
                                   subset=set(ingest_subset))
 

--- a/python/lsst/obs/base/ingest.py
+++ b/python/lsst/obs/base/ingest.py
@@ -28,7 +28,7 @@ from typing import List, Iterator, Iterable, Type, Optional, Any
 from collections import defaultdict
 from multiprocessing import Pool
 
-from astro_metadata_translator import ObservationInfo, fix_header, merge_headers
+from astro_metadata_translator import ObservationInfo, merge_headers
 from lsst.afw.fits import readMetadata
 from lsst.daf.butler import (
     Butler,
@@ -235,7 +235,6 @@ class RawIngestTask(Task):
             # we do not know in general if an input file has set INHERIT=T.
             phdu = readMetadata(filename, 0)
             header = merge_headers([phdu, readMetadata(filename)], mode="overwrite")
-            fix_header(header)
             datasets = [self._calculate_dataset_info(header, filename)]
         except Exception as e:
             self.log.debug("Problem extracting metadata from %s: %s", filename, e)


### PR DESCRIPTION
and remove unnecessary explicit call to `fix_header`.