### PR TITLE
DM-27178: Standardize aliases on Gen 2 Exposure get

### DIFF
--- a/python/lsst/obs/base/filters.py
+++ b/python/lsst/obs/base/filters.py
@@ -191,3 +191,8 @@ class FilterDefinition:
                                           lambdaMin=self.lambdaMin,
                                           lambdaMax=self.lambdaMax,
                                           alias=sorted(aliases))
+
+    def makeFilterLabel(self):
+        """Create a complete FilterLabel for this filter.
+        """
+        return lsst.afw.image.FilterLabel(band=self.band, physical=self.physical_filter)

--- a/python/lsst/obs/base/filters.py
+++ b/python/lsst/obs/base/filters.py
@@ -92,6 +92,31 @@ class FilterDefinitionCollection(collections.abc.Sequence):
         lsst.afw.image.utils.resetFilters()
         cls._defined = None
 
+    def findAll(self, name):
+        """Return the FilterDefinitions that match a particular name.
+
+        This method makes no attempt to prioritize, e.g., band names over
+        physical filter names; any definition that makes *any* reference
+        to the name is returned.
+
+        Parameters
+        ----------
+        name : `str`
+            The name to search for. May be any band, physical, or alias name.
+
+        Returns
+        -------
+        matches : `set` [`FilterDefinition`]
+            All FilterDefinitions containing ``name`` as one of their
+            filter names.
+        """
+        matches = set()
+        for filter in self._filters:
+            if name == filter.physical_filter or name == filter.band or name == filter.afw_name \
+                    or name in filter.alias:
+                matches.add(filter)
+        return matches
+
 
 @dataclasses.dataclass(frozen=True)
 class FilterDefinition:

--- a/tests/test_cameraMapper.py
+++ b/tests/test_cameraMapper.py
@@ -43,6 +43,37 @@ def setup_module(module):
     lsst.utils.tests.init()
 
 
+class MinCam(lsst.obs.base.Instrument):
+    @property
+    def filterDefinitions(self):
+        return lsst.obs.base.FilterDefinitionCollection(
+            lsst.obs.base.FilterDefinition(physical_filter="u.MP9301", band="u", lambdaEff=374),
+            lsst.obs.base.FilterDefinition(physical_filter="g.MP9401", band="g", lambdaEff=487),
+            lsst.obs.base.FilterDefinition(physical_filter="r.MP9601", band="r", alias={"old-r"},
+                                           lambdaEff=628),
+            lsst.obs.base.FilterDefinition(physical_filter="i.MP9701", band="i", lambdaEff=778),
+            lsst.obs.base.FilterDefinition(physical_filter="z.MP9801", band="z", lambdaEff=1170),
+            # afw_name is so special-cased that only a real example will work
+            lsst.obs.base.FilterDefinition(physical_filter="HSC-R2", band="r", afw_name="r2", lambdaEff=623),
+        )
+
+    @classmethod
+    def getName(cls):
+        return "min"
+
+    def getCamera(self):
+        raise NotImplementedError()
+
+    def register(self, registry):
+        raise NotImplementedError()
+
+    def getRawFormatter(self, dataId):
+        raise NotImplementedError()
+
+    def makeDataIdTranslatorFactory(self):
+        raise NotImplementedError()
+
+
 class MinMapper1(lsst.obs.base.CameraMapper):
     packageName = 'larry'
 
@@ -66,6 +97,7 @@ class MinMapper1(lsst.obs.base.CameraMapper):
 
 class MinMapper2(lsst.obs.base.CameraMapper):
     packageName = 'moe'
+    _gen3instrument = MinCam
 
     # CalibRoot in policy
     # needCalibRegistry

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -58,6 +58,13 @@ class TestFilterDefinitionCollection(lsst.utils.tests.TestCase):
         self.assertEqual(lsst.afw.image.Filter('abc').getFilterProperty().getLambdaEff(), 321)
         self.assertEqual(lsst.afw.image.Filter('def').getFilterProperty().getLambdaEff(), 654)
 
+    def test_findAll(self):
+        self.assertEqual(set(self.filters1.findAll('r')), set())
+        matches = self.filters1.findAll('abc')
+        self.assertEqual(len(matches), 1)
+        match = list(matches)[0]
+        self.assertEqual(match.physical_filter, 'abc')
+
 
 class TestFilterDefinition(lsst.utils.tests.TestCase):
     def setUp(self):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -112,6 +112,8 @@ class TestFilterDefinition(lsst.utils.tests.TestCase):
         filter = lsst.afw.image.Filter('physical')
         self.assertEqual(filter.getName(), 'physical')
         self.assertEqual([], sorted(filter.getAliases()))
+        self.assertEqual(self.physical_only.makeFilterLabel(),
+                         lsst.afw.image.FilterLabel(physical='physical'))
 
     def test_afw_name(self):
         """afw_name is the Filter name, physical_filter is an alias.
@@ -122,6 +124,8 @@ class TestFilterDefinition(lsst.utils.tests.TestCase):
         self.assertEqual(filter.getName(), 'afw only')
         self.assertEqual(filter_alias.getCanonicalName(), 'afw only')
         self.assertEqual(['afw_name'], sorted(filter.getAliases()))
+        self.assertEqual(self.afw_name.makeFilterLabel(),
+                         lsst.afw.image.FilterLabel(physical='afw_name'))
 
     def test_abstract_only(self):
         """band is the Filter name, physical_filter is an alias.
@@ -132,6 +136,8 @@ class TestFilterDefinition(lsst.utils.tests.TestCase):
         self.assertEqual(filter.getName(), 'abstract only')
         self.assertEqual(filter_alias.getCanonicalName(), 'abstract only')
         self.assertEqual(['abstract'], sorted(filter.getAliases()))
+        self.assertEqual(self.abstract.makeFilterLabel(),
+                         lsst.afw.image.FilterLabel(band='abstract only', physical='abstract'))
 
 
 class MemoryTester(lsst.utils.tests.MemoryTestCase):


### PR DESCRIPTION
This PR rewrites the Gen 2 filter-patching code to use `FilterLabel` instead of the less precise `Filter`, using any `FilterDefinition` objects as the source of truth for band and physical filter designations. For `obs` packages that do not use `FilterDefinition` (or, equivalently, `Instrument`), it falls back to the old behavior.

The new algorithm is intended to remove references to filter aliases from `Exposure` objects, and to disambiguate imperfectly converted old-style `Filters`. It is most important for calexps, which previously stored only the band name.