### PR TITLE
DM-28109: Test failure in obs_base test_cameraMapper.Mapper2TestCase

### DIFF
--- a/tests/test_cameraMapper.py
+++ b/tests/test_cameraMapper.py
@@ -218,6 +218,12 @@ class Mapper1TestCase(unittest.TestCase):
 class Mapper2TestCase(unittest.TestCase):
     """A test case for the mapper used by the data butler."""
 
+    def setUp(self):
+        super().setUp()
+        # Force a standard set of filters even for tests that don't use
+        # MinCam directly.
+        MinCam()
+
     def testGetDatasetTypes(self):
         mapper = MinMapper2(root=ROOT)
         expectedTypes = BaseMapper(ROOT).getDatasetTypes()


### PR DESCRIPTION
This PR fixes a bug where one of the test cases depended on `Filter` with specific filters, but, depending on test execution order, those filters were not guaranteed to have been registered.