### PR TITLE
DM-23985: Cannot do linearity corrections in Gen 3 DECam processing

### DIFF
--- a/python/lsst/obs/base/_instrument.py
+++ b/python/lsst/obs/base/_instrument.py
@@ -53,6 +53,7 @@ StandardCuratedCalibrationDatasetTypes = {
     "defects": {"dimensions": ("instrument", "detector"), "storageClass": "Defects"},
     "qe_curve": {"dimensions": ("instrument", "detector"), "storageClass": "QECurve"},
     "crosstalk": {"dimensions": ("instrument", "detector"), "storageClass": "CrosstalkCalib"},
+    "linearizer": {"dimensions": ("instrument", "detector"), "storageClass": "Linearizer"},
 }
 
 


### PR DESCRIPTION
Add linearizer to curated calib types.