### PR TITLE
DM-28459: Be more careful when defining afwFilter with duplicate bands

### DIFF
--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -123,7 +123,7 @@ class TestFilterDefinition(lsst.utils.tests.TestCase):
         self.assertEqual(filter2.getName(), 'g2')
         self.assertEqual(filter2_alias.getCanonicalName(), 'g2')
         self.assertEqual(filter2, filter2_alias)
-        self.assertEqual(['HIJK', 'HSC-G2', 'g'], sorted(filter2.getAliases()))
+        self.assertEqual(['HIJK', 'HSC-G2'], sorted(filter2.getAliases()))
 
     def test_physical_only(self):
         """physical_filter is the only name this filter has.


### PR DESCRIPTION
afwFilter is deprecated so rather than always assuming that
a band must be unique for afwFilter, if a duplicate band is
seen turn it into a bandN alias instead. This is an automated
version of what happens with i and i2 in HSC.