### PR TITLE
DM-29203: Flatten rerun chains when converting them.

### DIFF
--- a/python/lsst/obs/base/gen2to3/convertRepo.py
+++ b/python/lsst/obs/base/gen2to3/convertRepo.py
@@ -740,4 +740,4 @@ class ConvertRepoTask(Task):
                     # safe-ish to assume that's the one the rerun used.
                     chain.append(self.instrument.makeCalibrationCollectionName(*calibs[0].labels))
                 self.log.info("Defining %s from chain %s.", spec.chainName, chain)
-                self.butler3.registry.setCollectionChain(spec.chainName, chain)
+                self.butler3.registry.setCollectionChain(spec.chainName, chain, flatten=True)


### PR DESCRIPTION
This effectively resolves the Gen3 version of the sequence of parent repos up-front, protecting it from being changed by later changes to the definition of nested chains (like the default calibration collection).