### PR TITLE
DM-29313: FilterLabel is not properly filled in for CFHT raws

### DIFF
--- a/python/lsst/obs/base/cameraMapper.py
+++ b/python/lsst/obs/base/cameraMapper.py
@@ -1446,6 +1446,16 @@ def exposureFromImage(image, dataId=None, mapper=None, logger=None, setVisitInfo
     image : Image-like object
         Can be one of lsst.afw.image.DecoratedImage, Image, MaskedImage or
         Exposure.
+    dataId : `dict`, optional
+        The data ID identifying the visit of the image.
+    mapper : `lsst.obs.base.CameraMapper`, optional
+        The mapper with which to convert the image.
+    logger : `lsst.log.Log`, optional
+        An existing logger to which to send output.
+    setVisitInfo : `bool`, optional
+        If `True`, create and attach a `lsst.afw.image.VisitInfo` to the
+        result. Ignored if ``image`` is an `~lsst.afw.image.Exposure` with an
+        existing ``VisitInfo``.
 
     Returns
     -------

--- a/python/lsst/obs/base/cameraMapper.py
+++ b/python/lsst/obs/base/cameraMapper.py
@@ -1106,6 +1106,15 @@ class CameraMapper(dafPersist.Mapper):
                 newLabel = list(definitions)[0].makeFilterLabel()
                 return newLabel
             elif definitions:
+                # Some instruments have many filters for the same band, of
+                # which one is known by band name and the others always by
+                # afw name (e.g., i, i2).
+                nonAfw = {f for f in definitions if f.afw_name is None}
+                if len(nonAfw) == 1:
+                    newLabel = list(nonAfw)[0].makeFilterLabel()
+                    self.log.debug("Assuming %r is the correct match.", newLabel)
+                    return newLabel
+
                 self.log.warn("Multiple matches for filter %r with data ID %r.", storedLabel, idFilter)
                 # Can we at least add a band?
                 # Never expect multiple definitions with same physical filter.

--- a/python/lsst/obs/base/cameraMapper.py
+++ b/python/lsst/obs/base/cameraMapper.py
@@ -1437,7 +1437,7 @@ class CameraMapper(dafPersist.Mapper):
 def exposureFromImage(image, dataId=None, mapper=None, logger=None, setVisitInfo=True):
     """Generate an Exposure from an image-like object
 
-    If the image is a DecoratedImage then also set its WCS and metadata
+    If the image is a DecoratedImage then also set its metadata
     (Image and MaskedImage are missing the necessary metadata
     and Exposure already has those set)
 

--- a/tests/test_cameraMapper.py
+++ b/tests/test_cameraMapper.py
@@ -416,11 +416,12 @@ class Mapper2TestCase(unittest.TestCase):
         self.assertEqual(mapper.canStandardize("notPresent"), False)
 
     def testStandardizeFiltersFilterDefs(self):
+        # tuples are (input, desired output)
         testLabels = [
             (None, None),
             (afwImage.FilterLabel(band="i", physical="i.MP9701"),
              afwImage.FilterLabel(band="i", physical="i.MP9701")),
-            (afwImage.FilterLabel(band="i"), afwImage.FilterLabel(band="r", physical="i.MP9701")),
+            (afwImage.FilterLabel(band="i"), afwImage.FilterLabel(band="i", physical="i.MP9701")),
             (afwImage.FilterLabel(physical="i.MP9701"),
              afwImage.FilterLabel(band="i", physical="i.MP9701")),
             (afwImage.FilterLabel(band="i", physical="old-i"),
@@ -437,18 +438,12 @@ class Mapper2TestCase(unittest.TestCase):
         for input, corrected in testLabels:
             for dataId in testIds:
                 if input is None:
-                    if dataId["filter"] == "i":
-                        data = (input, dataId, afwImage.FilterLabel(band="i"))
-                    elif dataId["filter"] == "i2":
+                    if dataId["filter"] == "i2":
                         data = (input, dataId, afwImage.FilterLabel(band="i", physical="HSC-I2"))
                     else:
                         data = (input, dataId, afwImage.FilterLabel(band="i", physical="i.MP9701"))
-                elif input == afwImage.FilterLabel(band="i"):
-                    if dataId["filter"] == "i":
-                        # There are two "i" filters, can't tell which
-                        data = (input, dataId, input)
-                    elif dataId["filter"] == "i2":
-                        data = (input, dataId, afwImage.FilterLabel(band="i", physical="HSC-I2"))
+                elif input == afwImage.FilterLabel(band="i") and dataId["filter"] == "i2":
+                    data = (input, dataId, afwImage.FilterLabel(band="i", physical="HSC-I2"))
                 elif corrected.physicalLabel == "HSC-I2" and dataId["filter"] in ("i.MP9701", "old-i"):
                     # Contradictory inputs, leave as-is
                     data = (input, dataId, input)


### PR DESCRIPTION
This PR applies two fixes to filter ambiguity problems reported in Gen 2. The first preserves information read from non-`Exposure` image files, the second adds a rule to disambiguate a common case of multiple filters matching a single band.