### PR TITLE
DM-30301: Switch from lsst.log to python logging

### DIFF
--- a/python/lsst/obs/base/_fitsRawFormatterBase.py
+++ b/python/lsst/obs/base/_fitsRawFormatterBase.py
@@ -23,6 +23,7 @@ __all__ = ("FitsRawFormatterBase",)
 
 from abc import abstractmethod
 from deprecated.sphinx import deprecated
+import logging
 
 from astro_metadata_translator import fix_header, ObservationInfo
 
@@ -31,11 +32,12 @@ import lsst.afw.geom
 import lsst.afw.image
 from lsst.daf.butler import FileDescriptor
 from lsst.daf.butler.core.utils import cached_getter
-import lsst.log
 
 from .formatters.fitsExposure import FitsImageFormatterBase, standardizeAmplifierParameters
 from .makeRawVisitInfoViaObsInfo import MakeRawVisitInfoViaObsInfo
 from .utils import createInitialSkyWcsFromBoresight, InitialSkyWcsError
+
+log = logging.getLogger("fitsRawFormatter")
 
 
 class FitsRawFormatterBase(FitsImageFormatterBase):
@@ -227,7 +229,6 @@ class FitsRawFormatterBase(FitsImageFormatterBase):
 
         skyWcs = self._createSkyWcsFromMetadata()
 
-        log = lsst.log.Log.getLogger("fitsRawFormatter")
         if visitInfo is None:
             msg = "No VisitInfo; cannot access boresight information. Defaulting to metadata-based SkyWcs."
             log.warning(msg)
@@ -276,7 +277,6 @@ class FitsRawFormatterBase(FitsImageFormatterBase):
         try:
             return lsst.afw.geom.makeSkyWcs(self.metadata, strip=True)
         except TypeError as e:
-            log = lsst.log.Log.getLogger("fitsRawFormatter")
             log.warning("Cannot create a valid WCS from metadata: %s", e.args[0])
             return None
 

--- a/python/lsst/obs/base/gen2to3/convertTests.py
+++ b/python/lsst/obs/base/gen2to3/convertTests.py
@@ -24,6 +24,7 @@
 
 import abc
 import itertools
+import logging
 import shutil
 import tempfile
 import unittest
@@ -160,8 +161,8 @@ class ConvertGen2To3TestCase(metaclass=abc.ABCMeta):
         """
 
         # Turn on logging
-        log = lsst.log.Log.getLogger("convertRepo")
-        log.setLevel(log.INFO)
+        log = logging.getLogger("convertRepo")
+        log.setLevel(logging.INFO)
         log.info("Converting %s to %s", self.gen2root, self.gen3root)
 
         convert(repo=self.gen3root,

--- a/python/lsst/obs/base/gen2to3/repoWalker/parser.py
+++ b/python/lsst/obs/base/gen2to3/repoWalker/parser.py
@@ -26,11 +26,10 @@ from __future__ import annotations
 __all__ = ["PathElementParser"]
 
 
+import logging
 from abc import ABC, abstractmethod
 import re
 from typing import ClassVar, Dict, Optional
-
-from lsst.log import Log
 
 
 class FormattableRegEx(ABC):
@@ -189,7 +188,7 @@ class PathElementParser:
     def __str__(self):
         return f"{type(self).__name__}({self.regex})"
 
-    def parse(self, name: str, lastDataId: dict, *, log: Optional[Log] = None) -> Optional[dict]:
+    def parse(self, name: str, lastDataId: dict, *, log: Optional[logging.Logger] = None) -> Optional[dict]:
         """Parse the path element.
 
         Parameters
@@ -199,7 +198,7 @@ class PathElementParser:
         lastDataId : `dict`
             The cumulative Gen2 data ID obtaining by calling `parse` on parsers
             for parent directories of the same path.
-        log : `Log`, optional
+        log : `logging.Logger`, optional
             Log to use to report warnings and debug information.
 
         Returns

--- a/python/lsst/obs/base/gen2to3/repoWalker/scanner.py
+++ b/python/lsst/obs/base/gen2to3/repoWalker/scanner.py
@@ -31,6 +31,7 @@ __all__ = ["PathElementHandler", "DirectoryScanner"]
 
 from abc import ABC, abstractmethod
 import bisect
+import logging
 import os
 from typing import (
     Callable,
@@ -41,7 +42,6 @@ from typing import (
     Tuple,
 )
 
-from lsst.log import Log
 from lsst.daf.butler import (
     DataCoordinate,
     DatasetType,
@@ -152,8 +152,8 @@ class PathElementHandler(ABC):
     directory is entered, before invoking `__call__`.
     """
 
-    log: Log
-    """A logger to use for all diagnostic messages (`lsst.log.Log`).
+    log: logging.Logger
+    """A logger to use for all diagnostic messages (`logging.Logger`).
 
     This attribute is set on a handler in `DirectoryScanner.add`; this avoids
     needing to forward one through all subclass constructors.
@@ -166,16 +166,16 @@ class DirectoryScanner:
 
     Parameters
     ----------
-    log : `Log`, optional
+    log : `logging.Logger`, optional
         Log to use to report warnings and debug information.
     progress : `Progress`, optional
         Object to use to report incremental progress.
     """
-    def __init__(self, log: Optional[Log] = None, progress: Optional[Progress] = None):
+    def __init__(self, log: Optional[logging.Logger] = None, progress: Optional[Progress] = None):
         self._files = []
         self._subdirectories = []
         if log is None:
-            log = Log.getLogger("obs.base.gen2to3.walker")
+            log = logging.getLogger("obs.base.gen2to3.walker")
         self.log = log
         self.progress = progress
 

--- a/python/lsst/obs/base/gen2to3/repoWalker/walker.py
+++ b/python/lsst/obs/base/gen2to3/repoWalker/walker.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 __all__ = ["RepoWalker"]
 
 from collections import defaultdict
+import logging
 import re
 from typing import (
     Callable,
@@ -38,7 +39,6 @@ from typing import (
     Union,
 )
 
-from lsst.log import Log
 from lsst.daf.butler import (
     DataCoordinate,
     DatasetType,
@@ -74,11 +74,11 @@ class RepoWalker:
     def __init__(self, inputs: Iterable[Union[Target, Skip]], *,
                  fileIgnoreRegEx: Optional[re.Pattern] = None,
                  dirIgnoreRegEx: Optional[re.Pattern] = None,
-                 log: Optional[Log] = None,
+                 log: Optional[logging.Logger] = None,
                  progress: Optional[Progress] = None):
         super().__init__()
         if log is None:
-            log = Log.getLogger("obs.base.gen2to3.TranslatorFactory")
+            log = logging.getLogger("obs.base.gen2to3.TranslatorFactory")
         self.log = log
         tree = BuilderTree(progress)
         allKeys: Dict[str, type] = {}

--- a/python/lsst/obs/base/gen2to3/standardRepoConverter.py
+++ b/python/lsst/obs/base/gen2to3/standardRepoConverter.py
@@ -85,6 +85,7 @@ class StandardRepoConverter(RepoConverter):
     def __init__(self, **kwds):
         super().__init__(**kwds)
         # Shush noisy log messages from Gen2 Mapper classes.
+        # These are currently lsst.log loggers.
         with temporaryLogLevel("CameraMapper", Log.ERROR):
             with temporaryLogLevel("HscMapper", Log.ERROR):
                 self.butler2 = Butler2(self.root)

--- a/python/lsst/obs/base/gen2to3/translators.py
+++ b/python/lsst/obs/base/gen2to3/translators.py
@@ -27,8 +27,8 @@ __all__ = ("Translator", "TranslatorFactory", "KeyHandler", "CopyKeyHandler", "C
 import itertools
 from typing import Optional, Any, Dict, Tuple, FrozenSet, Iterable, List
 from abc import ABCMeta, abstractmethod
+import logging
 
-from lsst.log import Log
 from lsst.skymap import BaseSkyMap
 
 
@@ -238,10 +238,10 @@ class TranslatorFactory:
 
     Parameters
     ----------
-    log : `lsst.log.Log`, optional
+    log : `logging.Logger`, optional
         A logger for diagnostic messages.
     """
-    def __init__(self, log: Optional[Log] = None):
+    def __init__(self, log: Optional[logging.Logger] = None):
         # The rules used to match KeyHandlers when constructing a Translator.
         self._rules: Dict[
             Optional[str],  # instrument name (or None to match any)
@@ -257,7 +257,7 @@ class TranslatorFactory:
         }
         self._addDefaultRules()
         if log is None:
-            log = Log.getLogger("obs.base.gen2to3.TranslatorFactory")
+            log = logging.getLogger("obs.base.gen2to3.TranslatorFactory")
         self.log = log
 
     def __str__(self):
@@ -489,7 +489,7 @@ class Translator:
         Name of the dataset type whose data IDs this translator handles.
     """
     def __init__(self, handlers: List[KeyHandler], skyMap: Optional[BaseSkyMap], skyMapName: Optional[str],
-                 datasetTypeName: str, log: Log):
+                 datasetTypeName: str, log: logging.Logger):
         self.handlers = handlers
         self.skyMap = skyMap
         self.skyMapName = skyMapName

--- a/python/lsst/obs/base/makeRawVisitInfo.py
+++ b/python/lsst/obs/base/makeRawVisitInfo.py
@@ -19,20 +19,19 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+__all__ = ["MakeRawVisitInfo"]
+
 import math
+import logging
 import numpy as np
 
 import astropy.coordinates
 import astropy.time
 import astropy.units
 
-from lsst.log import Log
 from lsst.daf.base import DateTime
 from lsst.geom import degrees
 from lsst.afw.image import VisitInfo
-
-__all__ = ["MakeRawVisitInfo"]
-
 
 PascalPerMillibar = 100.0
 PascalPerMmHg = 133.322387415  # from Wikipedia; exact
@@ -65,16 +64,16 @@ class MakeRawVisitInfo:
 
     Parameters
     ----------
-    log : `lsst.log.Log` or None
+    log : `logging.Logger` or None
         Logger to use for messages.
-        (None to use ``Log.getLogger("MakeRawVisitInfo")``).
+        (None to use ``logging.getLogger("MakeRawVisitInfo")``).
     doStripHeader : `bool`, optional
         Strip header keywords from the metadata as they are used?
     """
 
     def __init__(self, log=None, doStripHeader=False):
         if log is None:
-            log = Log.getLogger("MakeRawVisitInfo")
+            log = logging.getLogger("MakeRawVisitInfo")
         self.log = log
         self.doStripHeader = doStripHeader
 

--- a/python/lsst/obs/base/makeRawVisitInfoViaObsInfo.py
+++ b/python/lsst/obs/base/makeRawVisitInfoViaObsInfo.py
@@ -19,6 +19,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+__all__ = ["MakeRawVisitInfoViaObsInfo"]
+
+import logging
 import warnings
 import astropy.units
 import astropy.utils.exceptions
@@ -34,14 +37,11 @@ except ImportError:
 
 from astro_metadata_translator import ObservationInfo
 
-from lsst.log import Log
 from lsst.daf.base import DateTime
 from lsst.geom import degrees, radians
 from lsst.afw.image import VisitInfo, RotType
 from lsst.afw.coord import Observatory, Weather
 from lsst.geom import SpherePoint
-
-__all__ = ["MakeRawVisitInfoViaObsInfo"]
 
 
 class MakeRawVisitInfoViaObsInfo:
@@ -58,7 +58,7 @@ class MakeRawVisitInfoViaObsInfo:
 
     Parameters
     ----------
-    log : `lsst.log.Log` or None
+    log : `logging.Logger` or None
         Logger to use for messages.
         (None to use ``Log.getLogger("MakeRawVisitInfoViaObsInfo")``).
     doStripHeader : `bool`, optional
@@ -71,7 +71,7 @@ class MakeRawVisitInfoViaObsInfo:
 
     def __init__(self, log=None, doStripHeader=False):
         if log is None:
-            log = Log.getLogger("MakeRawVisitInfoViaObsInfo")
+            log = logging.getLogger("MakeRawVisitInfoViaObsInfo")
         self.log = log
         self.doStripHeader = doStripHeader
 

--- a/python/lsst/obs/base/tests.py
+++ b/python/lsst/obs/base/tests.py
@@ -30,9 +30,8 @@ __all__ = (
     "make_ramp_exposure_untrimmed",
 )
 
+import logging
 import numpy as np
-
-from lsst.log import Log
 
 from lsst.afw.image import Exposure
 from lsst.afw.cameraGeom.utils import calcRawCcdBBox
@@ -40,8 +39,6 @@ from lsst.afw.cameraGeom.utils import calcRawCcdBBox
 from . import butler_tests
 from . import mapper_tests
 from . import camera_tests
-
-__all__ = ["ObsTests"]
 
 
 class ObsTests(butler_tests.ButlerGetTests, mapper_tests.MapperTests,
@@ -98,7 +95,7 @@ class ObsTests(butler_tests.ButlerGetTests, mapper_tests.MapperTests,
         self.butler = butler
         self.mapper = mapper
         self.dataIds = dataIds
-        self.log = Log.getLogger('ObsTests')
+        self.log = logging.getLogger('ObsTests')
 
     def tearDown(self):
         del self.butler

--- a/tests/test_fitsRawFormatter.py
+++ b/tests/test_fitsRawFormatter.py
@@ -143,9 +143,8 @@ class FitsRawFormatterTestCase(lsst.utils.tests.TestCase):
         self.metadataSkyWcs = lsst.afw.geom.makeSkyWcs(self.metadata, strip=False)
         self.boresightSkyWcs = createInitialSkyWcs(self.visitInfo, CameraWrapper().camera.get(10))
 
-        # set these to `contextlib.nullcontext()` to print the log warnings
+        # set this to `contextlib.nullcontext()` to print the log warnings
         self.warnContext = self.assertLogs(level="WARNING")
-        self.logContext = lsst.log.UsePythonLogging()
 
         # Make a data ID to pass to the formatter.
         universe = lsst.daf.butler.DimensionUniverse()
@@ -169,7 +168,7 @@ class FitsRawFormatterTestCase(lsst.utils.tests.TestCase):
         """
         detector = self.formatter.getDetector(1)
         self.metadata.remove("CTYPE1")
-        with self.warnContext, self.logContext:
+        with self.warnContext:
             wcs = self.formatter.makeWcs(self.visitInfo, detector)
         self.assertNotEqual(wcs, self.metadataSkyWcs)
         self.assertEqual(wcs, self.boresightSkyWcs)
@@ -178,7 +177,7 @@ class FitsRawFormatterTestCase(lsst.utils.tests.TestCase):
         """If VisitInfo is None, log a warning and use the metadata WCS.
         """
         detector = self.formatter.getDetector(1)
-        with self.warnContext, self.logContext:
+        with self.warnContext:
             wcs = self.formatter.makeWcs(None, detector)
         self.assertEqual(wcs, self.metadataSkyWcs)
         self.assertNotEqual(wcs, self.boresightSkyWcs)
@@ -188,7 +187,7 @@ class FitsRawFormatterTestCase(lsst.utils.tests.TestCase):
         """
         detector = self.formatter.getDetector(1)
         self.metadata.remove("CTYPE1")
-        with self.warnContext, self.logContext, self.assertRaises(InitialSkyWcsError):
+        with self.warnContext, self.assertRaises(InitialSkyWcsError):
             self.formatter.makeWcs(None, detector)
 
     def test_makeWcs_fail_if_detector_is_bad(self):

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -26,7 +26,6 @@ import shutil
 import tempfile
 import unittest
 
-import lsst.log
 import lsst.daf.butler.tests as butlerTests
 from lsst.daf.butler import DatasetType, Butler, DataCoordinate, Config
 from lsst.daf.butler.registry import ConflictingDefinitionError
@@ -156,8 +155,7 @@ datastore:
         new_run = self.outputRun + "c"
 
         with self.assertLogs(level="WARNING") as cm:
-            with lsst.log.UsePythonLogging():
-                self.task.run(files, run=new_run)
+            self.task.run(files, run=new_run)
         self.assertIn("already specified in an index file, ignoring content", cm.output[0])
 
         datasets = list(self.butler.registry.queryDatasets("raw_dict", collections=self.outputRun))
@@ -170,8 +168,7 @@ datastore:
                  os.path.join(INGESTDIR, "indexed_data", "_index.json")]
         new_run = self.outputRun + "d"
         with self.assertLogs(level="WARNING") as cm:
-            with lsst.log.UsePythonLogging():
-                self.task.run(files, run=new_run)
+            self.task.run(files, run=new_run)
         self.assertIn("already specified in an index file but overriding", cm.output[0])
 
         # Reversing the order should change the warning.
@@ -183,8 +180,7 @@ datastore:
 
         new_run = self.outputRun + "e"
         with self.assertLogs(level="WARNING") as cm:
-            with lsst.log.UsePythonLogging():
-                self.task.run(files, run=new_run)
+            self.task.run(files, run=new_run)
         self.assertIn("already specified in an index file, ignoring", cm.output[0])
 
         # Bad index file.
@@ -195,9 +191,8 @@ datastore:
         # Bad index file due to bad instrument.
         files = [os.path.join(INGESTDIR, "indexed_data", "bad_instrument", "_index.json")]
         with self.assertLogs(level="WARNING") as cm:
-            with lsst.log.UsePythonLogging():
-                with self.assertRaises(RuntimeError):
-                    self.task.run(files, run=self.outputRun)
+            with self.assertRaises(RuntimeError):
+                self.task.run(files, run=self.outputRun)
         self.assertIn("Instrument HSC for file", cm.output[0])
 
     def testBadExposure(self):

--- a/tests/test_makeRawVisitInfoViaObsInfo.py
+++ b/tests/test_makeRawVisitInfoViaObsInfo.py
@@ -24,10 +24,9 @@ import unittest
 from astropy.time import Time
 import astropy.units as u
 
-import lsst.log
 from astro_metadata_translator import FitsTranslator, StubTranslator, ObservationInfo
 from lsst.daf.base import DateTime
-
+import lsst.afw.image
 from lsst.obs.base import MakeRawVisitInfoViaObsInfo
 
 
@@ -78,9 +77,8 @@ class TestMakeRawVisitInfoViaObsInfo(unittest.TestCase):
         # Capture the warnings from StubTranslator since they are
         # confusing to people but irrelevant for the test.
         with self.assertWarns(UserWarning):
-            with lsst.log.UsePythonLogging():
-                with self.assertLogs(level="WARNING"):
-                    visitInfo = maker(self.header)
+            with self.assertLogs(level="WARNING"):
+                visitInfo = maker(self.header)
 
         self.assertAlmostEqual(visitInfo.getExposureTime(), self.exposure_time.to_value("s"))
         # TODO DM-13943: note that in this test visitInfo.getExposureId() and


### PR DESCRIPTION
This allows the removal of the usePythonLogging redirect.

No changes were made to gen2 mapper loggers.
The 2to3 conversion code still uses lsst.log to ensure that
mapper logs are hidden properly.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
