### PR TITLE
DM-31903: Add update option to instrument-registration operations.

### DIFF
--- a/doc/changes/DM-31903.feature.md
+++ b/doc/changes/DM-31903.feature.md
@@ -1,0 +1,1 @@
+Add support for forced updates of `instrument`, `detector`, and `physical_filter` definitions during instrument registration.

--- a/python/lsst/obs/base/cli/cmd/commands.py
+++ b/python/lsst/obs/base/cli/cmd/commands.py
@@ -121,6 +121,7 @@ def ingest_raws(*args, **kwargs):
 @click.command(short_help="Add an instrument to the repository", cls=ButlerCommand)
 @repo_argument(required=True)
 @instrument_argument(required=True, nargs=-1, help="The fully-qualified name of an Instrument subclass.")
+@click.option("--update", is_flag=True)
 def register_instrument(*args, **kwargs):
     """Add an instrument to the data repository.
     """

--- a/python/lsst/obs/base/instrument_tests.py
+++ b/python/lsst/obs/base/instrument_tests.py
@@ -77,7 +77,7 @@ class DummyCam(Instrument):
         filename = pkg_resources.resource_filename("lsst.obs.base", "test/dummycam.yaml")
         return makeCamera(filename)
 
-    def register(self, registry):
+    def register(self, registry, update=False):
         """Insert Instrument, physical_filter, and detector entries into a
         `Registry`.
         """
@@ -85,11 +85,12 @@ class DummyCam(Instrument):
         dataId = {"instrument": self.getName(), "class_name": getFullTypeName(DummyCam),
                   "detector_max": detector_max}
         with registry.transaction():
-            registry.syncDimensionData("instrument", dataId)
-            self._registerFilters(registry)
+            registry.syncDimensionData("instrument", dataId, update=update)
+            self._registerFilters(registry, update=update)
             for d in range(detector_max):
                 registry.syncDimensionData("detector",
-                                           dict(dataId, id=d, full_name=f"RXX_S0{d}"))
+                                           dict(dataId, id=d, full_name=f"RXX_S0{d}",),
+                                           update=update)
 
     def getRawFormatter(self, dataId):
         # Docstring inherited fromt Instrument.getRawFormatter.

--- a/python/lsst/obs/base/script/registerInstrument.py
+++ b/python/lsst/obs/base/script/registerInstrument.py
@@ -23,7 +23,7 @@ from lsst.daf.butler import Butler
 from ..utils import getInstrument
 
 
-def registerInstrument(repo, instrument):
+def registerInstrument(repo, instrument, update):
     """Add an instrument to the data repository.
 
     Parameters
@@ -32,6 +32,9 @@ def registerInstrument(repo, instrument):
         URI to the location to create the repo.
     instrument : `list` [`str`]
         The fully-qualified name of an Instrument subclass.
+    update : `bool`, optional
+        If `True` (`False` is default), update the existing instrument and
+        detector records if they differ from the new ones.
 
     Raises
     ------
@@ -44,4 +47,4 @@ def registerInstrument(repo, instrument):
     butler = Butler(repo, writeable=True)
     for instr in instrument:
         instrInstance = getInstrument(instr, butler.registry)
-        instrInstance.register(butler.registry)
+        instrInstance.register(butler.registry, update=update)

--- a/tests/test_cliCmdRegisterInstrument.py
+++ b/tests/test_cliCmdRegisterInstrument.py
@@ -44,7 +44,8 @@ class RegisterInstrumentTest(CliCmdTestBase, unittest.TestCase):
         """Test the most basic required arguments."""
         self.run_test(["register-instrument", "here", "a.b.c"],
                       self.makeExpected(repo="here",
-                                        instrument=("a.b.c",)))
+                                        instrument=("a.b.c",),
+                                        update=False))
 
     def test_missing(self):
         """test a missing argument"""


### PR DESCRIPTION
For the most part this just changes the interface, requiring downstream
implementations in concrete obs_* packages.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
