### PR TITLE
DM-31903, hotfix: add default to new registerInstrument script command option.

### DIFF
--- a/python/lsst/obs/base/script/registerInstrument.py
+++ b/python/lsst/obs/base/script/registerInstrument.py
@@ -23,7 +23,7 @@ from lsst.daf.butler import Butler
 from ..utils import getInstrument
 
 
-def registerInstrument(repo, instrument, update):
+def registerInstrument(repo, instrument, update=False):
     """Add an instrument to the data repository.
 
     Parameters


### PR DESCRIPTION
This restores backwards compatibility with the signature prior to DM-31903, though downstream code really should not be using these script functions (ci_builder does, and that led to DM-31903 breaking ci_imsim; I've created DM-31915 to address that, as it's not something I want to hotfix).

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
