### PR TITLE
DM-31722: Use lsst.utils.introspection.get_full_type_name instead

### DIFF
--- a/python/lsst/obs/base/instrument_tests.py
+++ b/python/lsst/obs/base/instrument_tests.py
@@ -35,7 +35,7 @@ from lsst.obs.base.gen2to3 import TranslatorFactory
 from lsst.obs.base.yamlCamera import makeCamera
 from lsst.daf.butler import Registry
 from lsst.daf.butler import RegistryConfig
-from lsst.daf.butler.core.utils import getFullTypeName
+from lsst.utils.introspection import get_full_type_name
 from lsst.daf.butler.formatters.yaml import YamlFormatter
 
 from .utils import createInitialSkyWcsFromBoresight
@@ -82,7 +82,7 @@ class DummyCam(Instrument):
         `Registry`.
         """
         detector_max = 2
-        dataId = {"instrument": self.getName(), "class_name": getFullTypeName(DummyCam),
+        dataId = {"instrument": self.getName(), "class_name": get_full_type_name(DummyCam),
                   "detector_max": detector_max}
         with registry.transaction():
             registry.syncDimensionData("instrument", dataId, update=update)

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -29,7 +29,7 @@ import unittest
 import lsst.daf.butler.tests as butlerTests
 from lsst.daf.butler import DatasetType, Butler, DataCoordinate, Config
 from lsst.daf.butler.registry import ConflictingDefinitionError
-from lsst.daf.butler.core.utils import getFullTypeName
+from lsst.utils.introspection import get_full_type_name
 
 from lsst.obs.base.ingest_tests import IngestTestBase
 from lsst.obs.base.instrument_tests import DummyCam
@@ -55,7 +55,7 @@ class RawIngestTestCase(IngestTestBase, unittest.TestCase):
     """Test ingest using JSON sidecar files."""
 
     ingestDatasetTypeName = "raw_dict"
-    rawIngestTask = getFullTypeName(DummyCamRawIngestTask)
+    rawIngestTask = get_full_type_name(DummyCamRawIngestTask)
     curatedCalibrationDatasetTypes = ()
     ingestDir = TESTDIR
     instrumentClassName = "lsst.obs.base.instrument_tests.DummyCam"


### PR DESCRIPTION
## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
