### PR TITLE
DM-29955: Add ExposureInfo id getter

### DIFF
--- a/python/lsst/obs/base/_fitsRawFormatterBase.py
+++ b/python/lsst/obs/base/_fitsRawFormatterBase.py
@@ -397,6 +397,7 @@ class FitsRawFormatterBase(FitsImageFormatterBase):
             have a detector attached.
         """
         info = exposure.getInfo()
+        info.id = self.observationInfo.detector_exposure_id
         info.setFilterLabel(self.makeFilterLabel())
         info.setVisitInfo(self.makeVisitInfo())
         info.setWcs(self.makeWcs(info.getVisitInfo(), info.getDetector()))

--- a/python/lsst/obs/base/cameraMapper.py
+++ b/python/lsst/obs/base/cameraMapper.py
@@ -1495,6 +1495,14 @@ def exposureFromImage(image, dataId=None, mapper=None, logger=None, setVisitInfo
     else:  # Image
         exposure = afwImage.makeExposure(afwImage.makeMaskedImage(image))
 
+    # set exposure ID if we can
+    if not exposure.info.hasId() and mapper is not None:
+        try:
+            exposureId = mapper._computeCcdExposureId(dataId)
+            exposure.info.id = exposureId
+        except NotImplementedError:
+            logger.warning("Could not set exposure ID; mapper does not support it.")
+
     if metadata is not None:
         # set filter if we can
         if setFilter and mapper is not None and exposure.getFilterLabel() is None:

--- a/python/lsst/obs/base/exposureAssembler.py
+++ b/python/lsst/obs/base/exposureAssembler.py
@@ -37,7 +37,7 @@ class ExposureAssembler(StorageClassDelegate):
     EXPOSURE_COMPONENTS = set(("image", "variance", "mask", "wcs", "psf"))
     EXPOSURE_INFO_COMPONENTS = set(("apCorrMap", "coaddInputs", "photoCalib", "metadata",
                                     "filterLabel", "transmissionCurve", "visitInfo",
-                                    "detector", "validPolygon", "summaryStats"))
+                                    "detector", "validPolygon", "summaryStats", "id"))
     EXPOSURE_READ_COMPONENTS = {"bbox", "dimensions", "xy0", "filter"}
 
     COMPONENT_MAP = {"bbox": "BBox", "xy0": "XY0"}
@@ -236,6 +236,9 @@ class ExposureAssembler(StorageClassDelegate):
         info = exposure.getInfo()
         if "visitInfo" in components:
             info.setVisitInfo(components.pop("visitInfo"))
+        # Override ID set in visitInfo, if necessary
+        if "id" in components:
+            info.id = components.pop("id")
         info.setApCorrMap(components.pop("apCorrMap", None))
         info.setCoaddInputs(components.pop("coaddInputs", None))
         info.setMetadata(components.pop("metadata", None))
@@ -290,6 +293,7 @@ class ExposureAssembler(StorageClassDelegate):
             "dimensions": imageComponents,
             "xy0": imageComponents,
             "filter": ["filterLabel"],
+            "id": ["metadata"],
         }
         forwarder = forwarderMap.get(readComponent)
         if forwarder is not None:

--- a/python/lsst/obs/base/formatters/fitsExposure.py
+++ b/python/lsst/obs/base/formatters/fitsExposure.py
@@ -516,6 +516,7 @@ class FitsExposureFormatter(FitsMaskedImageFormatter):
         # Other components have hard-coded method names, but don't take
         # parameters.
         standardComponents = {
+            'id': 'readExposureId',
             'metadata': 'readMetadata',
             'wcs': 'readWcs',
             'coaddInputs': 'readCoaddInputs',


### PR DESCRIPTION
This PR adds an `id` component to `ExposureInfo`, in keeping with the changes to the persistence handling made on lsst/afw#613. It also supplements existing uses of `setVisitInfo` with `setId`.