### PR TITLE
DM-13943: Deprecate VisitInfo.getExposureId()

### DIFF
--- a/tests/test_butlerFits.py
+++ b/tests/test_butlerFits.py
@@ -288,7 +288,7 @@ class ButlerFitsTests(DatasetTestHelper, lsst.utils.tests.TestCase):
             elif compName == "filterLabel":
                 self.assertEqual(component, reference)
             elif compName == "visitInfo":
-                self.assertEqual(component.getExposureId(), reference.getExposureId(),
+                self.assertEqual(component, reference,
                                  "VisitInfo comparison")
             elif compName == "metadata":
                 # The component metadata has extra fields in it so cannot

--- a/tests/test_makeRawVisitInfo.py
+++ b/tests/test_makeRawVisitInfo.py
@@ -75,7 +75,9 @@ class VisitInfoTestCase(lsst.utils.tests.TestCase):
         })
         length = len(md)
         visitInfo = self.makeRawVisitInfo(md=md, exposureId=exposureId)
-        self.assertEqual(visitInfo.getExposureId(), exposureId)
+        with self.assertWarns(FutureWarning):
+            # TODO: tested for backward-compatibility; remove on DM-32138
+            self.assertEqual(visitInfo.getExposureId(), exposureId)
         self.assertEqual(md.nameCount(), length)  # No stripping
         self.assertEqual(visitInfo.getExposureTime(), exposureTime)
         self.assertEqual(visitInfo.getDate(), date)

--- a/tests/test_makeRawVisitInfoViaObsInfo.py
+++ b/tests/test_makeRawVisitInfoViaObsInfo.py
@@ -81,9 +81,9 @@ class TestMakeRawVisitInfoViaObsInfo(unittest.TestCase):
                 visitInfo = maker(self.header)
 
         self.assertAlmostEqual(visitInfo.getExposureTime(), self.exposure_time.to_value("s"))
-        # TODO DM-13943: note that in this test visitInfo.getExposureId() and
-        # visitInfo.id are the same, but that's not true generally.
-        self.assertEqual(visitInfo.getExposureId(), self.exposure_id)
+        with self.assertWarns(FutureWarning):
+            # TODO: tested for backward-compatibility; remove on DM-32138
+            self.assertEqual(visitInfo.getExposureId(), self.exposure_id)
         self.assertEqual(visitInfo.id, self.exposure_id)
         self.assertEqual(visitInfo.getDate(), DateTime("2001-01-02T03:04:06.123456789Z", DateTime.UTC))
         # The header can possibly grow with header fix up provenance.
@@ -99,9 +99,9 @@ class TestMakeRawVisitInfoViaObsInfo(unittest.TestCase):
         visitInfo = MakeRawVisitInfoViaObsInfo.observationInfo2visitInfo(obsInfo)
         self.assertIsInstance(visitInfo, lsst.afw.image.VisitInfo)
         self.assertAlmostEqual(visitInfo.getExposureTime(), self.exposure_time.to_value("s"))
-        # TODO DM-13943: note that in this test visitInfo.getExposureId() and
-        # visitInfo.id are the same, but that's not true generally.
-        self.assertEqual(visitInfo.getExposureId(), self.exposure_id)
+        with self.assertWarns(FutureWarning):
+            # TODO: tested for backward-compatibility; remove on DM-32138
+            self.assertEqual(visitInfo.getExposureId(), self.exposure_id)
         self.assertEqual(visitInfo.id, self.exposure_id)
         self.assertEqual(visitInfo.getDate(), DateTime("2001-01-02T03:04:06.123456789Z", DateTime.UTC))
         self.assertEqual(visitInfo.getInstrumentLabel(), "SomeCamera")


### PR DESCRIPTION
This PR removes a gratuitous use of `VisitInfo.getExposureId()`, but preserves those used to test `VisitInfo` functionality.