### PR TITLE
DM-32058: Fix newly-revealed preexisting bug in defineVisits test.

### DIFF
--- a/python/lsst/obs/base/ingest_tests.py
+++ b/python/lsst/obs/base/ingest_tests.py
@@ -421,7 +421,7 @@ class IngestTestBase(metaclass=abc.ABCMeta):
         # folder are generally considered protected and should not be used
         # as public api.
         script.defineVisits(self.root, config_file=None, collections=self.outputRun,
-                            instrument=self.instrumentName)
+                            instrument=self.instrumentName, raw_name=self.ingestDatasetTypeName)
 
         # Test that we got the visits we expected.
         butler = Butler(self.root, run=self.outputRun)

--- a/python/lsst/obs/base/script/defineVisits.py
+++ b/python/lsst/obs/base/script/defineVisits.py
@@ -27,7 +27,7 @@ from ..utils import getInstrument
 log = logging.getLogger("defineVisits")
 
 
-def defineVisits(repo, config_file, collections, instrument, processes=1):
+def defineVisits(repo, config_file, collections, instrument, processes=1, raw_name="raw"):
     """Implements the command line interface `butler define-visits` subcommand,
     should only be called by command line tools and unit test code that tests
     this function.
@@ -46,6 +46,8 @@ def defineVisits(repo, config_file, collections, instrument, processes=1):
         If empty it will be passed as `None` to Butler.
     instrument : `str`
         The name or fully-qualified class name of an instrument.
+    raw_name : `str`, optional
+        Name of the raw dataset type name.  Defaults to 'raw'.
 
     Notes
     -----
@@ -71,5 +73,5 @@ def defineVisits(repo, config_file, collections, instrument, processes=1):
     # Assume the dataset type is "raw" -- this is required to allow this
     # query to filter out exposures not relevant to the specified collection.
     task.run(butler.registry.queryDataIds(["exposure"], dataId={"instrument": instr.getName()},
-                                          collections=collections, datasets="raw"),
+                                          collections=collections, datasets=raw_name),
              collections=collections, processes=processes)


### PR DESCRIPTION
I'm not entirely sure how this worked before - the test uses "raw_dict"
as the dataset type name for raws, while calling a script that
hard-coded "raw" for that name.  But daf_butler changes on this ticket
caused the ticket to fail, and this change was always the right fix.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
