### PR TITLE
DM-32414: Exposure ID Gen 3 disassembled component broken

### DIFF
--- a/python/lsst/obs/base/exposureAssembler.py
+++ b/python/lsst/obs/base/exposureAssembler.py
@@ -236,7 +236,9 @@ class ExposureAssembler(StorageClassDelegate):
         info = exposure.getInfo()
         if "visitInfo" in components:
             info.setVisitInfo(components.pop("visitInfo"))
-        # Override ID set in visitInfo, if necessary
+        # Until DM-32138, "visitInfo" and "id" can both set the exposure ID.
+        # While they should always be consistent unless a component is
+        # corrupted, handle "id" second to ensure it takes precedence.
         if "id" in components:
             info.id = components.pop("id")
         info.setApCorrMap(components.pop("apCorrMap", None))

--- a/python/lsst/obs/base/exposureAssembler.py
+++ b/python/lsst/obs/base/exposureAssembler.py
@@ -293,7 +293,6 @@ class ExposureAssembler(StorageClassDelegate):
             "dimensions": imageComponents,
             "xy0": imageComponents,
             "filter": ["filterLabel"],
-            "id": ["metadata"],
         }
         forwarder = forwarderMap.get(readComponent)
         if forwarder is not None:

--- a/tests/test_butlerFits.py
+++ b/tests/test_butlerFits.py
@@ -81,7 +81,9 @@ datastore:
 
 # Components present in the test file
 COMPONENTS = {"wcs", "image", "mask", "coaddInputs", "psf", "visitInfo", "variance", "metadata", "photoCalib",
-              "filterLabel", "validPolygon", "transmissionCurve", "detector", "apCorrMap", "summaryStats"}
+              "filterLabel", "validPolygon", "transmissionCurve", "detector", "apCorrMap", "summaryStats",
+              "id",
+              }
 READ_COMPONENTS = {"bbox", "xy0", "dimensions", "filter"}
 
 
@@ -286,6 +288,8 @@ class ButlerFitsTests(DatasetTestHelper, lsst.utils.tests.TestCase):
             elif compName == "filter":
                 self.assertEqual(component.getCanonicalName(), reference.getCanonicalName())
             elif compName == "filterLabel":
+                self.assertEqual(component, reference)
+            elif compName == "id":
                 self.assertEqual(component, reference)
             elif compName == "visitInfo":
                 self.assertEqual(component, reference,


### PR DESCRIPTION
This PR adds unit tests for the `exposure.id` Butler component added on #394. It also makes some minor changes to bring the code in line with lsst/daf_butler#594.