### PR TITLE
DM-32843: Backport of v23 release notes

### DIFF
--- a/doc/changes/DM-28636.feature.rst
+++ b/doc/changes/DM-28636.feature.rst
@@ -1,1 +1,0 @@
-2to3 conversion has been improved to add a dry run facility, to defer dataId expansion when not required, and to allow templates to be overridden.

--- a/doc/changes/DM-28698.feature.rst
+++ b/doc/changes/DM-28698.feature.rst
@@ -1,1 +1,0 @@
-Reorganize the base ``Exposure`` and raw formatters to improve efficiency and clarify component handling.

--- a/doc/changes/DM-29370.feature.rst
+++ b/doc/changes/DM-29370.feature.rst
@@ -1,1 +1,0 @@
-Add ``amp`` parameter to the formatters for the Exposure StorageClass, allowing single-amplifier subimage reads.

--- a/doc/changes/DM-29794.bugfix.rst
+++ b/doc/changes/DM-29794.bugfix.rst
@@ -1,1 +1,0 @@
-Not all PSFs are persistable and now if one is encountered as part of composite disassembly it will be ignored. These types of PSFs were already silently dropped when writing a full ``Exposure``.

--- a/doc/changes/DM-29950.feature.rst
+++ b/doc/changes/DM-29950.feature.rst
@@ -1,1 +1,0 @@
-Change raw ingest to use a reproducible UUID5 dataset ID. This means that the dataset ID for a raw ingested in one repository will be identical to that used in another.  For integer-based registries this change will have no effect.

--- a/doc/changes/DM-30866.feature.rst
+++ b/doc/changes/DM-30866.feature.rst
@@ -1,1 +1,0 @@
-Add support for updating exposure and visit definitions in RawIngestTask and DefineVisitsTask.

--- a/doc/changes/DM-31079.bugfix.rst
+++ b/doc/changes/DM-31079.bugfix.rst
@@ -1,1 +1,0 @@
-The ``butler define-visits`` command now correctly uses the ``--collections`` option to constrain the exposures that will be processed into visits.

--- a/doc/changes/DM-31903.feature.md
+++ b/doc/changes/DM-31903.feature.md
@@ -1,1 +1,0 @@
-Add support for forced updates of `instrument`, `detector`, and `physical_filter` definitions during instrument registration.

--- a/doc/lsst.obs.base/CHANGES.rst
+++ b/doc/lsst.obs.base/CHANGES.rst
@@ -1,3 +1,24 @@
+obs_base v23.0.0 2021-12-10
+===========================
+
+New Features
+------------
+
+- 2to3 conversion has been improved to add a dry run facility, to defer dataId expansion when not required, and to allow templates to be overridden. (`DM-28636 <https://jira.lsstcorp.org/browse/DM-28636>`_)
+- Reorganize the base ``Exposure`` and raw formatters to improve efficiency and clarify component handling. (`DM-28698 <https://jira.lsstcorp.org/browse/DM-28698>`_)
+- Add ``amp`` parameter to the formatters for the Exposure StorageClass, allowing single-amplifier subimage reads. (`DM-29370 <https://jira.lsstcorp.org/browse/DM-29370>`_)
+- Change raw ingest to use a reproducible UUID5 dataset ID. This means that the dataset ID for a raw ingested in one repository will be identical to that used in another.  For integer-based registries this change will have no effect. (`DM-29950 <https://jira.lsstcorp.org/browse/DM-29950>`_)
+- Add support for updating exposure and visit definitions in RawIngestTask and DefineVisitsTask. (`DM-30866 <https://jira.lsstcorp.org/browse/DM-30866>`_)
+- Add support for forced updates of `instrument`, `detector`, and `physical_filter` definitions during instrument registration. (`DM-31903 <https://jira.lsstcorp.org/browse/DM-31903>`_)
+
+
+Bug Fixes
+---------
+
+- Not all PSFs are persistable and now if one is encountered as part of composite disassembly it will be ignored. These types of PSFs were already silently dropped when writing a full ``Exposure``. (`DM-29794 <https://jira.lsstcorp.org/browse/DM-29794>`_)
+- The ``butler define-visits`` command now correctly uses the ``--collections`` option to constrain the exposures that will be processed into visits. (`DM-31079 <https://jira.lsstcorp.org/browse/DM-31079>`_)
+
+
 obs_base v22.0 (2021-04-01)
 ===========================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,16 +28,11 @@
         showcontent = true
 
     [[tool.towncrier.type]]
-        directory = "other"
-        name = "Other Changes and Additions"
-        showcontent = false
-
-    [[tool.towncrier.type]]
         directory = "misc"
-        name = "Miscellaneous Changes of Minor Interest"
-        showcontent = false
+        name = "Other Changes and Additions"
+        showcontent = true
 
     [[tool.towncrier.type]]
         directory = "removal"
         name = "An API Removal or Deprecation"
-        showcontent = false
+        showcontent = true


### PR DESCRIPTION
## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
