### PR TITLE
DM-33086: Add --track-files-attrs option to butler ingest-raws

### DIFF
--- a/doc/changes/DM-33086.api.rst
+++ b/doc/changes/DM-33086.api.rst
@@ -1,0 +1,3 @@
+Add a new option ``--track-file-attrs`` to ``butler ingest-raws``.
+This controls whether the ingested files should have file sizes and checksums tracked by the datastore.
+Use ``--no-track-files-attrs`` to disable size tracking.

--- a/python/lsst/obs/base/cli/cmd/commands.py
+++ b/python/lsst/obs/base/cli/cmd/commands.py
@@ -125,6 +125,13 @@ def define_visits(*args, **kwargs):
     default="lsst.obs.base.RawIngestTask",
     help="The fully qualified class name of the ingest task to use.",
 )
+@click.option(
+    "--track-file-attrs/--no-track-file-attrs",
+    default=True,
+    help="Indicate to the datastore whether file attributes such as file size"
+    " or checksum should be tracked or not. Whether this parameter is honored"
+    " depends on the specific datastore implentation.",
+)
 @options_file_option()
 def ingest_raws(*args, **kwargs):
     """Ingest raw frames into from a directory into the butler registry"""

--- a/python/lsst/obs/base/ingest.py
+++ b/python/lsst/obs/base/ingest.py
@@ -870,6 +870,7 @@ class RawIngestTask(Task):
         *,
         run: Optional[str] = None,
         skip_existing_exposures: bool = False,
+        track_file_attrs: bool = True,
     ) -> List[FileDataset]:
         """Ingest all raw files in one exposure.
 
@@ -894,6 +895,10 @@ class RawIngestTask(Task):
             processes may still attempt to ingest the same raw and conflict,
             causing a failure that prevents other raws from the same exposure
             from being ingested.
+        track_file_attrs : `bool`, optional
+            Control whether file attributes such as the size or checksum should
+            be tracked by the datastore. Whether this parameter is honored
+            depends on the specific datastore implentation.
 
         Returns
         -------
@@ -926,7 +931,13 @@ class RawIngestTask(Task):
             mode = DatasetIdGenEnum.DATAID_TYPE_RUN
         else:
             mode = DatasetIdGenEnum.UNIQUE
-        self.butler.ingest(*datasets, transfer=self.config.transfer, run=run, idGenerationMode=mode)
+        self.butler.ingest(
+            *datasets,
+            transfer=self.config.transfer,
+            run=run,
+            idGenerationMode=mode,
+            record_validation_info=track_file_attrs,
+        )
         return datasets
 
     def ingestFiles(
@@ -938,6 +949,7 @@ class RawIngestTask(Task):
         run: Optional[str] = None,
         skip_existing_exposures: bool = False,
         update_exposure_records: bool = False,
+        track_file_attrs: bool = True,
     ):
         """Ingest files into a Butler data repository.
 
@@ -977,6 +989,10 @@ class RawIngestTask(Task):
             AN ADVANCED OPTION THAT SHOULD ONLY BE USED TO FIX METADATA THAT IS
             KNOWN TO BE BAD.  This should usually be combined with
             ``skip_existing_exposures=True``.
+        track_file_attrs : `bool`, optional
+            Control whether file attributes such as the size or checksum should
+            be tracked by the datastore. Whether this parameter is honored
+            depends on the specific datastore implentation.
 
         Returns
         -------
@@ -1053,6 +1069,7 @@ class RawIngestTask(Task):
                     exposure,
                     run=this_run,
                     skip_existing_exposures=skip_existing_exposures,
+                    track_file_attrs=track_file_attrs,
                 )
             except Exception as e:
                 self._on_ingest_failure(exposure, e)
@@ -1088,6 +1105,7 @@ class RawIngestTask(Task):
         group_files: bool = True,
         skip_existing_exposures: bool = False,
         update_exposure_records: bool = False,
+        track_file_attrs: bool = True,
     ):
         """Ingest files into a Butler data repository.
 
@@ -1135,6 +1153,10 @@ class RawIngestTask(Task):
             AN ADVANCED OPTION THAT SHOULD ONLY BE USED TO FIX METADATA THAT IS
             KNOWN TO BE BAD.  This should usually be combined with
             ``skip_existing_exposures=True``.
+        track_file_attrs : `bool`, optional
+            Control whether file attributes such as the size or checksum should
+            be tracked by the datastore. Whether this parameter is honored
+            depends on the specific datastore implentation.
 
         Returns
         -------
@@ -1165,6 +1187,7 @@ class RawIngestTask(Task):
                     run=run,
                     skip_existing_exposures=skip_existing_exposures,
                     update_exposure_records=update_exposure_records,
+                    track_file_attrs=track_file_attrs,
                 )
                 refs.extend(new_refs)
                 bad_files.extend(bad)

--- a/python/lsst/obs/base/script/ingestRaws.py
+++ b/python/lsst/obs/base/script/ingestRaws.py
@@ -34,6 +34,7 @@ def ingestRaws(
     transfer="auto",
     processes=1,
     ingest_task="lsst.obs.base.RawIngestTask",
+    track_file_attrs=True,
 ):
     """Ingests raw frames into the butler registry
 
@@ -59,6 +60,10 @@ def ingestRaws(
     ingest_task : `str`
         The fully qualified class name of the ingest task to use by default
         lsst.obs.base.RawIngestTask.
+    track_file_attrs : `bool`, optional
+        Control whether file attributes such as the size or checksum should
+        be tracked by the datastore. Whether this parameter is honored
+        depends on the specific datastore implentation.
 
     Raises
     ------
@@ -77,4 +82,6 @@ def ingestRaws(
             configOverrides.addValueOverride(name, value)
     configOverrides.applyTo(ingestConfig)
     ingester = TaskClass(config=ingestConfig, butler=butler)
-    ingester.run(locations, run=output_run, processes=processes, file_filter=regex)
+    ingester.run(
+        locations, run=output_run, processes=processes, file_filter=regex, track_file_attrs=track_file_attrs
+    )

--- a/tests/test_cliCmdTestIngest.py
+++ b/tests/test_cliCmdTestIngest.py
@@ -49,6 +49,7 @@ class IngestRawsTestCase(CliCmdTestBase, unittest.TestCase):
             processes=1,
             regex=fits_re,
             transfer="auto",
+            track_file_attrs=True,
         )
 
     @staticmethod


### PR DESCRIPTION
This controls whether file sizes and checksums should
be recorded by the datastore or not. Whether a datastore
cares is up to the datastore.

Requires lsst/daf_butler#628

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
