### PR TITLE
DM-33783: Remove internal multiprocessing from DefineVisitsTask.

### DIFF
--- a/doc/changes/DM-33783.removal.rst
+++ b/doc/changes/DM-33783.removal.rst
@@ -1,0 +1,2 @@
+Remove the ``processes`` and ``pool`` arguments and the ``--processes`` command-line argument from `DefineVisitsTask.run` and ``butler define-visits`` (respectively).
+These were already broken for ``processes > 1``, and internal parallelization here is no longer useful now that this task just does database I/O, not raw metadata reads.

--- a/python/lsst/obs/base/cli/cmd/commands.py
+++ b/python/lsst/obs/base/cli/cmd/commands.py
@@ -94,7 +94,6 @@ def convert(*args, **kwargs):
     callback=split_commas,
     metavar=typeStrAcceptsMultiple,
 )
-@processes_option()
 @options_file_option()
 def define_visits(*args, **kwargs):
     """Define visits from exposures in the butler registry.

--- a/python/lsst/obs/base/gen2to3/convertRepo.py
+++ b/python/lsst/obs/base/gen2to3/convertRepo.py
@@ -736,7 +736,7 @@ class ConvertRepoTask(Task):
 
         # Define visits (also does nothing if we weren't configurd to convert
         # the 'raw' dataset type).
-        rootConverter.runDefineVisits(pool=pool)
+        rootConverter.runDefineVisits()
 
         # Insert dimensions that are potentially shared by all Gen2
         # repositories (and are hence managed directly by the Task, rather

--- a/python/lsst/obs/base/gen2to3/rootRepoConverter.py
+++ b/python/lsst/obs/base/gen2to3/rootRepoConverter.py
@@ -132,7 +132,7 @@ class RootRepoConverter(StandardRepoConverter):
             )
         self._chain = [self.task.raws.butler.run]
 
-    def runDefineVisits(self, pool=None):
+    def runDefineVisits(self):
         if self.task.defineVisits is None:
             self.task.log.info("Skipping visit definition for %s.", self.root)
             return
@@ -140,7 +140,7 @@ class RootRepoConverter(StandardRepoConverter):
         exposureDataIds = set(ref.dataId.subset(dimensions) for ref in self._rawRefs)
         if not self.task.dry_run:
             self.task.log.info("Defining visits from exposures.")
-            self.task.defineVisits.run(exposureDataIds, pool=pool)
+            self.task.defineVisits.run(exposureDataIds)
         else:
             self.task.log.info("[dry run] Skipping defining visits from exposures.")
 

--- a/python/lsst/obs/base/script/defineVisits.py
+++ b/python/lsst/obs/base/script/defineVisits.py
@@ -28,7 +28,7 @@ from ..utils import getInstrument
 log = logging.getLogger("lsst.obs.base.defineVisits")
 
 
-def defineVisits(repo, config_file, collections, instrument, processes=1, raw_name="raw"):
+def defineVisits(repo, config_file, collections, instrument, raw_name="raw"):
     """Implements the command line interface `butler define-visits` subcommand,
     should only be called by command line tools and unit test code that tests
     this function.
@@ -78,5 +78,4 @@ def defineVisits(repo, config_file, collections, instrument, processes=1, raw_na
             ["exposure"], dataId={"instrument": instr.getName()}, collections=collections, datasets=raw_name
         ),
         collections=collections,
-        processes=processes,
     )

--- a/tests/test_cliCmdDefineVisits.py
+++ b/tests/test_cliCmdDefineVisits.py
@@ -44,7 +44,7 @@ class DefineVisitsTest(CliCmdTestBase, unittest.TestCase):
         """Test the most basic required arguments."""
         self.run_test(
             ["define-visits", "here", "a.b.c"],
-            self.makeExpected(repo="here", processes=1, instrument="a.b.c"),
+            self.makeExpected(repo="here", instrument="a.b.c"),
         )
 
     def test_all(self):
@@ -58,8 +58,6 @@ class DefineVisitsTest(CliCmdTestBase, unittest.TestCase):
                 "foo/bar,baz",
                 "--config-file",
                 "/path/to/config",
-                "--processes",
-                2,
                 "--collections",
                 "boz",
             ],
@@ -67,7 +65,6 @@ class DefineVisitsTest(CliCmdTestBase, unittest.TestCase):
                 repo="here",
                 instrument="a.b.c",
                 config_file="/path/to/config",
-                processes=2,
                 # The list of collections must be in
                 # exactly the same order as it is
                 # passed in the list of arguments to


### PR DESCRIPTION
This had stopped working a while ago, if it ever worked at all, and
with us now creating raw WCSs from Registry's DimensionRecords instead
of reading raw files, it's not worth trying to get working.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
