### PR TITLE
DM-33848: Allow visits to be defined for anything that is on-sky

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ config.log
 *Lib.py
 .cache
 .pytest_cache
-.coverage
+.coverage*
 bin/
 doc/html
 doc/*.tag
@@ -22,6 +22,7 @@ doc/doxygen.conf
 tests/.tests
 tests/.cache
 tests/Test*-*
+tests/tmp*
 version.py
 tests/trivial_camera/qe_curves/ccd00/19700101T000000.ecsv
 tests/trivial_camera/qe_curves/ccd00/19800101T000000.ecsv

--- a/doc/changes/DM-33848.feature.rst
+++ b/doc/changes/DM-33848.feature.rst
@@ -1,0 +1,3 @@
+* Visits will now be defined for all on-sky observations regardless of the observation type.
+* Changed `butler define-visits` so that it now takes a `--where` option.
+  This can be used to restrict the visit definition to specific exposures.

--- a/python/lsst/obs/base/cli/cmd/commands.py
+++ b/python/lsst/obs/base/cli/cmd/commands.py
@@ -30,6 +30,7 @@ from lsst.daf.butler.cli.opt import (
     repo_argument,
     run_option,
     transfer_option,
+    where_option,
 )
 from lsst.daf.butler.cli.utils import ButlerCommand, split_commas, typeStrAcceptsMultiple
 
@@ -94,6 +95,7 @@ def convert(*args, **kwargs):
     callback=split_commas,
     metavar=typeStrAcceptsMultiple,
 )
+@where_option()
 @options_file_option()
 def define_visits(*args, **kwargs):
     """Define visits from exposures in the butler registry.

--- a/python/lsst/obs/base/defineVisits.py
+++ b/python/lsst/obs/base/defineVisits.py
@@ -493,18 +493,18 @@ class DefineVisitsTask(Task):
         for dataId in data_id_set:
             record = dataId.records["exposure"]
             assert record is not None, "Guaranteed by expandDataIds call earlier."
-            if record.observation_type != "science":
+            if record.tracking_ra is None or record.tracking_dec is None or record.sky_angle is None:
                 if self.config.ignoreNonScienceExposures:
                     continue
                 else:
                     raise RuntimeError(
                         f"Input exposure {dataId} has observation_type "
-                        f"{record.observation_type}, not 'science'."
+                        f"{record.observation_type}, but is not on sky."
                     )
             instruments.add(dataId["instrument"])
             exposures.append(record)
         if not exposures:
-            self.log.info("No science exposures found after filtering.")
+            self.log.info("No on-sky exposures found after filtering.")
             return
         if len(instruments) > 1:
             raise RuntimeError(

--- a/python/lsst/obs/base/script/defineVisits.py
+++ b/python/lsst/obs/base/script/defineVisits.py
@@ -28,7 +28,7 @@ from ..utils import getInstrument
 log = logging.getLogger("lsst.obs.base.defineVisits")
 
 
-def defineVisits(repo, config_file, collections, instrument, raw_name="raw"):
+def defineVisits(repo, config_file, collections, instrument, where=None, raw_name="raw"):
     """Implements the command line interface `butler define-visits` subcommand,
     should only be called by command line tools and unit test code that tests
     this function.
@@ -47,6 +47,9 @@ def defineVisits(repo, config_file, collections, instrument, raw_name="raw"):
         If empty it will be passed as `None` to Butler.
     instrument : `str`
         The name or fully-qualified class name of an instrument.
+    where : `str`, optional
+        Query clause to use when querying for dataIds. Can be used to limit
+        the relevant exposures.
     raw_name : `str`, optional
         Name of the raw dataset type name.  Defaults to 'raw'.
 
@@ -67,6 +70,9 @@ def defineVisits(repo, config_file, collections, instrument, raw_name="raw"):
         collections = instr.makeDefaultRawIngestRunName()
         log.info("Defaulting to searching for raw exposures in collection %s", collections)
 
+    if not where:
+        where = None
+
     if config_file is not None:
         config.load(config_file)
     task = DefineVisitsTask(config=config, butler=butler)
@@ -75,7 +81,11 @@ def defineVisits(repo, config_file, collections, instrument, raw_name="raw"):
     # query to filter out exposures not relevant to the specified collection.
     task.run(
         butler.registry.queryDataIds(
-            ["exposure"], dataId={"instrument": instr.getName()}, collections=collections, datasets=raw_name
+            ["exposure"],
+            dataId={"instrument": instr.getName()},
+            collections=collections,
+            datasets=raw_name,
+            where=where,
         ),
         collections=collections,
     )

--- a/tests/test_cliCmdDefineVisits.py
+++ b/tests/test_cliCmdDefineVisits.py
@@ -44,7 +44,7 @@ class DefineVisitsTest(CliCmdTestBase, unittest.TestCase):
         """Test the most basic required arguments."""
         self.run_test(
             ["define-visits", "here", "a.b.c"],
-            self.makeExpected(repo="here", instrument="a.b.c"),
+            self.makeExpected(repo="here", instrument="a.b.c", where=None),
         )
 
     def test_all(self):
@@ -70,6 +70,7 @@ class DefineVisitsTest(CliCmdTestBase, unittest.TestCase):
                 # passed in the list of arguments to
                 # run_test.
                 collections=("foo/bar", "baz", "boz"),
+                where=None,
             ),
         )
 


### PR DESCRIPTION
"on sky" is defined as having a tracking RA/Dec defined. This is more flexible than relying on specific observation type values.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
