### PR TITLE
DM-33891-hotfix add a default value to ingestRaws fail_fast argument

### DIFF
--- a/doc/changes/DM-33891-hotfix.bugfix.rst
+++ b/doc/changes/DM-33891-hotfix.bugfix.rst
@@ -1,0 +1,1 @@
+Add a default value to the script.ingestRaws fail_fast argument.

--- a/python/lsst/obs/base/script/ingestRaws.py
+++ b/python/lsst/obs/base/script/ingestRaws.py
@@ -29,7 +29,7 @@ def ingestRaws(
     locations,
     regex,
     output_run,
-    fail_fast,
+    fail_fast=False,
     config=None,
     config_file=None,
     transfer="auto",


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
