### PR TITLE
DM-34175: Simplify ingest with extended exposure table and related dimensions

### DIFF
--- a/python/lsst/obs/base/_instrument.py
+++ b/python/lsst/obs/base/_instrument.py
@@ -871,7 +871,8 @@ class Instrument(metaclass=ABCMeta):
         return "/".join((self.collection_prefix,) + labels)
 
 
-def makeExposureRecordFromObsInfo(obsInfo: ObservationInfo, universe: DimensionUniverse) -> DimensionRecord:
+def makeExposureRecordFromObsInfo(obsInfo: ObservationInfo, universe: DimensionUniverse, **kwargs: Any
+    ) -> DimensionRecord:
     """Construct an exposure DimensionRecord from
     `astro_metadata_translator.ObservationInfo`.
 
@@ -882,6 +883,8 @@ def makeExposureRecordFromObsInfo(obsInfo: ObservationInfo, universe: DimensionU
         the exposure.
     universe : `DimensionUniverse`
         Set of all known dimensions.
+    **kwargs
+        Additional field values for this record.
 
     Returns
     -------
@@ -923,6 +926,7 @@ def makeExposureRecordFromObsInfo(obsInfo: ObservationInfo, universe: DimensionU
         tracking_dec=dec,
         sky_angle=sky_angle,
         zenith_angle=zenith_angle,
+        **kwargs
     )
 
 


### PR DESCRIPTION
When instruments need additional exposure properties and/or
dimensions, they need a way to provide that information to the
RawIngestTask. We already have the ability to subclass the
RawIngestTask (via the --ingest-task command-line argument),
but there was no way for the subtask to specify the additional
information.

Moved some defaults (the ObservationInfo class and the list of
required ObservationInfo fields) into class variables, and added
methods to provide the required registry records. An important
conceptual addition is the idea of 'extra records': records
which are added to the registry in addition to the exposure
record. These can be used to satisfy foreign key constraints
when the exposure relates to dimensions beyond the standard set.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
