### PR TITLE
DM-12659: Fix C++ import of pure-Python package

### DIFF
--- a/ups/obs_base.cfg
+++ b/ups/obs_base.cfg
@@ -3,7 +3,7 @@
 import lsst.sconsUtils
 
 dependencies = {
-    "required": ["utils", "pex_exceptions"]
+    "required": ["cpputils", "pex_exceptions"]
 }
 
 config = lsst.sconsUtils.Configuration(


### PR DESCRIPTION
This PR stops C++ imports of `utils`, which as a pure-Python package no longer supports such imports. It's `cpputils` that could produce headers and libraries.