### PR TITLE
DM-35917: Note that --config no longer splits on comma

### DIFF
--- a/doc/changes/DM-35917.api.rst
+++ b/doc/changes/DM-35917.api.rst
@@ -1,0 +1,3 @@
+The ``ingest-raws`` and ``define-visits`` subcommands no longer allow multiple config settings within a single ``--config`` option.
+We have decided that it is too dangerous to split on comma in the general case and so have removed that facility to be consistent with other commands.
+Use multiple ``--config`` options instead.

--- a/tests/test_cliCmdTestIngest.py
+++ b/tests/test_cliCmdTestIngest.py
@@ -76,7 +76,9 @@ class IngestRawsTestCase(CliCmdTestBase, unittest.TestCase):
                 "-c",
                 "foo=1",
                 "--config",
-                "bar=2,baz=3",
+                "bar=2",
+                "--config",
+                "baz=3",
             ],
             self.makeExpected(
                 repo="repo",


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
