### PR TITLE
DM-36598: Fix to check parent dir if there are no sub-dirs.

### DIFF
--- a/doc/changes/DM-36598.bugfix.md
+++ b/doc/changes/DM-36598.bugfix.md
@@ -1,0 +1,1 @@
+Fix curated calibration reading to check parent directory if there are no sub-directories.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,3 +44,6 @@ target-version = ["py310"]
 [tool.isort]
 profile = "black"
 line_length = 110
+
+[tool.lsst_versions]
+write_to = "python/lsst/obs/base/version.py"

--- a/python/lsst/obs/base/_read_curated_calibs.py
+++ b/python/lsst/obs/base/_read_curated_calibs.py
@@ -229,7 +229,7 @@ def read_all(
     dirs = os.listdir(root)  # assumes all directories contain data
     dirs = [d for d in dirs if os.path.isdir(os.path.join(root, d))]
     if not dirs:
-        raise RuntimeError(f"No data found on path {root}")
+        dirs = [root]
 
     calib_types = set()
     # We assume the directories have been lowered.

--- a/types.txt
+++ b/types.txt
@@ -1,6 +1,5 @@
 types-requests
 types-PyYAML
-types-click
 types-pkg_resources
 types-Deprecated
 types-python-dateutil


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
