### PR TITLE
DM-37652: Fix logic when warning about a missing exposure in visit

### DIFF
--- a/python/lsst/obs/base/defineVisits.py
+++ b/python/lsst/obs/base/defineVisits.py
@@ -889,7 +889,7 @@ class _GroupExposuresByCounterAndExposuresTask(GroupExposuresTask, metaclass=ABC
                 # Special case seq_num == 0 since that implies that the
                 # instrument has no counters and therefore no multi-exposure
                 # visits.
-                if first.seq_num == 0:
+                if first.seq_num != 0:
                     self.log.warning(
                         "First exposure for visit %s is not present. Skipping the multi-snap definition.",
                         visit_key,


### PR DESCRIPTION
The code was warning when the seq_num was 0 but it should have been warning when the seq_num was NOT 0 (since those scenarios never have visits and so should never warn)

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
