### PR TITLE
DM-38205: Add obscore update code to DefineVisitsTask

### DIFF
--- a/doc/changes/DM-38205.feature.md
+++ b/doc/changes/DM-38205.feature.md
@@ -1,0 +1,2 @@
+`DefineVisitsTask` now calls ObsCore table manager to update exposure regions after visit is defined.
+New configuration field `updateObsCoreTable` for that task can be set to `False` to disable exposure updates.

--- a/python/lsst/obs/base/ingest_tests.py
+++ b/python/lsst/obs/base/ingest_tests.py
@@ -33,7 +33,7 @@ import unittest
 import lsst.afw.cameraGeom
 import lsst.afw.cameraGeom.testUtils  # For assertDetectorsEqual
 import lsst.obs.base
-from lsst.daf.butler import Butler
+from lsst.daf.butler import Butler, Registry
 from lsst.daf.butler.cli.butler import cli as butlerCli
 from lsst.daf.butler.cli.utils import LogCliRunner
 from lsst.pipe.base import Instrument
@@ -442,6 +442,10 @@ class IngestTestBase(metaclass=abc.ABCMeta):
             self.skipTest("Expected visits were not defined.")
         self._ingestRaws(transfer="link")
 
+        # Check that obscore table (if configured) has correct contents.
+        butler = Butler(self.root, run=self.outputRun)
+        self._check_obscore(butler.registry, has_visits=False)
+
         # Calling defineVisits tests the implementation of the butler command
         # line interface "define-visits" subcommand. Functions in the script
         # folder are generally considered protected and should not be used
@@ -455,7 +459,6 @@ class IngestTestBase(metaclass=abc.ABCMeta):
         )
 
         # Test that we got the visits we expected.
-        butler = Butler(self.root, run=self.outputRun)
         visits = butler.registry.queryDataIds(["visit"]).expanded().toSet()
         self.assertCountEqual(visits, self.visits.keys())
         instr = Instrument.from_string(self.instrumentName, butler.registry)
@@ -478,3 +481,10 @@ class IngestTestBase(metaclass=abc.ABCMeta):
 
                 idInfo = lsst.obs.base.ExposureIdInfo.fromDataId(dataId)
                 self.assertGreater(idInfo.unusedBits, 0)
+
+        # Check obscore table again.
+        self._check_obscore(butler.registry, has_visits=True)
+
+    def _check_obscore(self, registry: Registry, has_visits: bool) -> None:
+        """Verify contents of obscore table."""
+        return

--- a/tests/data/curated/obscore.yaml
+++ b/tests/data/curated/obscore.yaml
@@ -1,0 +1,46 @@
+# Config file for obscore in obs_base test
+cls: lsst.daf.butler.registry.obscore._manager.ObsCoreLiveTableManager
+config:
+  namespace: test
+  version: 1
+  facility_name: obs-base-test
+  obs_collection: OBS_BASE_TEST
+  collection_type: RUN
+  collections: null
+  use_butler_uri: false
+  dataset_types:
+    raw_dict:  # Must match dataset type name defined in RawIngestTestCase
+      dataproduct_type: image  # We do not care about correct values for some fields
+      dataproduct_subtype: lsst.raw
+      calib_level: 1
+      obs_id_fmt: "{records[exposure].obs_id}-{records[detector].full_name}"
+      o_ucd: phot.count
+      access_format: image/fits
+  extra_columns:
+    lsst_visit:
+      template: "{visit}"
+      type: "int"
+    lsst_exposure:
+      template: "{exposure}"
+      type: "int"
+    lsst_detector:
+      template: "{detector}"
+      type: "int"
+    lsst_band:
+      template: "{band}"
+      type: "string"
+      length: 32
+    lsst_filter:
+      template: "{physical_filter}"
+      type: "string"
+      length: 32
+    lsst_dataset_type:
+      template: "{dataset_type}"
+      type: "string"
+      length: 64
+    lsst_run:
+      template: "{run}"
+      type: "string"
+      length: 255
+  spectral_ranges:
+    "u": [330.0e-9, 400.0e-9]

--- a/tests/data/curated/seed.yaml
+++ b/tests/data/curated/seed.yaml
@@ -1,3 +1,6 @@
+registry:
+  managers:
+    obscore: !include obscore.yaml
 datastore:
   formatters:
     CuratedCalibration: lsst.daf.butler.formatters.json.JsonFormatter


### PR DESCRIPTION
Once visit and its regions are defined in registry we need to update matching exposure records with the region information. DefineVisitsTask adds an option (enabled by default) to call obscore manager (if that is configured for a repo) method to do that update.

## Checklist

- [X] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
