### PR TITLE
DM-38678: Expand dataset refs before passing them to DefineVisitsTask

### DIFF
--- a/python/lsst/obs/base/script/defineVisits.py
+++ b/python/lsst/obs/base/script/defineVisits.py
@@ -99,6 +99,6 @@ def defineVisits(repo, config_file, collections, instrument, where=None, raw_nam
             collections=collections,
             datasets=raw_name,
             where=where,
-        ),
+        ).expanded(),
         collections=collections,
     )


### PR DESCRIPTION
DefineVisitsTask calls `expandDataId()` internaly to expand each dataset ref in a loop, but this is not a recommended way. This patch adds `expanded()` call on the iterator before passing it to the task to achieve the same. I have not removed `expandDataId()` from the task, as it may be also be used in other contexts which use un-expanded refs.

## Checklist

- [X] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
