### PR TITLE
DM-38922: Remove "by-group-metadata" visit system.

### DIFF
--- a/doc/changes/DM-38922.removal.md
+++ b/doc/changes/DM-38922.removal.md
@@ -1,0 +1,3 @@
+Remove (without deprecation) the "by-group-metadata" visit definition system.
+
+This has been fully superseded by the "one-to-one-and-by-counter" option.


### PR DESCRIPTION
This has been superseded by the "one-to-one-and-by-counter" system, and we don't want anyone using it since that'd create a mess in data repositories we'd have to clean up.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
