### PR TITLE
DM-38520: Use the known translator class to fix header in formatter

### DIFF
--- a/python/lsst/obs/base/_fitsRawFormatterBase.py
+++ b/python/lsst/obs/base/_fitsRawFormatterBase.py
@@ -161,7 +161,7 @@ class FitsRawFormatterBase(FitsImageFormatterBase):
             Header metadata.
         """
         md = lsst.afw.fits.readMetadata(self.fileDescriptor.location.path)
-        fix_header(md)
+        fix_header(md, translator_class=self.translatorClass)
         return md
 
     def stripMetadata(self):


### PR DESCRIPTION
It's inefficient to ask the fix_header function to work it out for itself if the formatter already knows the answer.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
