### PR TITLE
DM-37253: Fix deprecation warning for ExposureIdInfo.

### DIFF
--- a/python/lsst/obs/base/exposureIdInfo.py
+++ b/python/lsst/obs/base/exposureIdInfo.py
@@ -31,7 +31,7 @@ from lsst.daf.butler import DataCoordinate
 
 
 @deprecated(
-    "Deprecated in favor of lsst.meas.base.CatalogIdPacker; will be removed after v27.",
+    "Deprecated in favor of `lsst.meas.base.IdGenerator`; will be removed after v27.",
     version="v26",
     category=FutureWarning,
 )


### PR DESCRIPTION
The old warning referred to lsst.meas.base.CatalogIdPacker, a class that does not exist.