### PR TITLE
DM-39764: Remove use of pkg_resources

### DIFF
--- a/python/lsst/obs/base/instrument_tests.py
+++ b/python/lsst/obs/base/instrument_tests.py
@@ -41,11 +41,11 @@ import json
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any, ClassVar, Optional, Sequence, Set
 
-import pkg_resources
 from lsst.daf.butler import CollectionType, DatasetType, Registry, RegistryConfig
 from lsst.daf.butler.formatters.yaml import YamlFormatter
 from lsst.obs.base import FilterDefinition, FilterDefinitionCollection, Instrument
 from lsst.obs.base.yamlCamera import makeCamera
+from lsst.resources import ResourcePath
 from lsst.utils.introspection import get_full_type_name
 from pydantic import BaseModel
 
@@ -122,8 +122,8 @@ class DummyCam(Instrument):
     def getCamera(self):
         # Return something that can be indexed by detector number
         # but also has to support getIdIter.
-        filename = pkg_resources.resource_filename("lsst.obs.base", "test/dummycam.yaml")
-        return makeCamera(filename)
+        with ResourcePath("resource://lsst.obs.base/test/dummycam.yaml").as_local() as local_file:
+            return makeCamera(local_file.ospath)
 
     def register(self, registry, update=False):
         """Insert Instrument, physical_filter, and detector entries into a

--- a/tests/test_yamlCamera.py
+++ b/tests/test_yamlCamera.py
@@ -21,19 +21,20 @@
 
 import unittest
 
-import pkg_resources
 from lsst.obs.base.yamlCamera import makeCamera
+from lsst.resources import ResourcePath
 
 
 class YamlCameraTestCase(unittest.TestCase):
     """Test the YAML camera geometry."""
 
     def setUp(self):
-        self.cameraFile = pkg_resources.resource_filename("lsst.obs.base", "test/dummycam.yaml")
+        self.cameraFile = ResourcePath("resource://lsst.obs.base/test/dummycam.yaml")
 
     def test_basics(self):
         """Basic test of yaml camera construction"""
-        camera = makeCamera(self.cameraFile)
+        with self.cameraFile.as_local() as local_file:
+            camera = makeCamera(local_file.ospath)
 
         self.assertEqual(len(camera), 2)
         self.assertEqual(camera[0].getName(), "RXX_S00")

--- a/types.txt
+++ b/types.txt
@@ -1,5 +1,4 @@
 types-requests
 types-PyYAML
-types-pkg_resources
 types-Deprecated
 types-python-dateutil


### PR DESCRIPTION
pkg_resources has been deprecated for a while.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
