### PR TITLE
DM-41043: Fix bad symbol reference in docs.

### DIFF
--- a/python/lsst/obs/base/_instrument.py
+++ b/python/lsst/obs/base/_instrument.py
@@ -199,7 +199,7 @@ class Instrument(InstrumentBase):
 
         Parameters
         ----------
-        registry : `lsst.daf.butler.core.Registry`
+        registry : `lsst.daf.butler.Registry`
             The registry to add dimensions to.
         update : `bool`, optional
             If `True` (`False` is default), update existing records if they


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
