### PR TITLE
DM-41330: Force visitInfo to use the dataId exposure value

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,20 +1,20 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
       - id: check-toml
   - repo: https://github.com/psf/black
-    rev: 23.7.0
+    rev: 23.10.1
     hooks:
       - id: black
         # It is recommended to specify the latest version of Python
         # supported by your project here, or alternatively use
         # pre-commit's default_language_version, see
         # https://pre-commit.com/#top_level-default_language_version
-        language_version: python3.10
+        language_version: python3.11
   - repo: https://github.com/pycqa/isort
     rev: 5.12.0
     hooks:
@@ -22,6 +22,6 @@ repos:
         name: isort (python)
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.0.278
+    rev: v0.1.2
     hooks:
       - id: ruff

--- a/python/lsst/obs/base/_fitsRawFormatterBase.py
+++ b/python/lsst/obs/base/_fitsRawFormatterBase.py
@@ -179,7 +179,17 @@ class FitsRawFormatterBase(FitsImageFormatterBase):
         visitInfo : `~lsst.afw.image.VisitInfo`
             Structured metadata about the observation.
         """
-        return MakeRawVisitInfoViaObsInfo.observationInfo2visitInfo(self.observationInfo)
+        visit_info = MakeRawVisitInfoViaObsInfo.observationInfo2visitInfo(self.observationInfo)
+        if self.dataId and "exposure" in self.dataId:
+            # Special case exposure existing for this dataset type.
+            # Want to ensure that the id stored in the visitInfo matches that
+            # from the dataId from butler, regardless of what may have come
+            # from the ObservationInfo. In some edge cases they might differ.
+            exposure_id = self.dataId["exposure"]
+            if exposure_id != visit_info.id:
+                visit_info = visit_info.copyWith(id=exposure_id)
+
+        return visit_info
 
     @abstractmethod
     def getDetector(self, id):

--- a/tests/test_fitsRawFormatter.py
+++ b/tests/test_fitsRawFormatter.py
@@ -230,6 +230,7 @@ class FitsRawFormatterTestCase(lsst.utils.tests.TestCase):
                             self.assertImagesEqual(subexp.image, full[amp.getRawBBox()].image)
                             self.assertEqual(len(subexp.getDetector()), 1)
                             self.assertAmplifiersEqual(subexp.getDetector()[0], amp)
+                            self.assertEqual(subexp.visitInfo.id, 2)
                 # We could try transformed amplifiers here that involve flips
                 # and offsets, but:
                 # - we already test the low-level code that does that in afw;


### PR DESCRIPTION
## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
