### PR TITLE
DM-41724: Fix bad detector record construction in tests.

### DIFF
--- a/python/lsst/obs/base/defineVisits.py
+++ b/python/lsst/obs/base/defineVisits.py
@@ -518,10 +518,7 @@ class DefineVisitsTask(Task):
         )
         if observation_reason is None:
             # Be explicit about there being multiple reasons
-            # MyPy can't really handle DimensionRecord fields as
-            # DimensionRecord classes are dynamically defined; easiest to just
-            # shush it when it complains.
-            observation_reason = "various"  # type: ignore
+            observation_reason = "various"
 
         # Use the mean zenith angle as an approximation
         zenith_angle = _reduceOrNone(operator.add, (e.zenith_angle for e in definition.exposures))

--- a/python/lsst/obs/base/instrument_tests.py
+++ b/python/lsst/obs/base/instrument_tests.py
@@ -148,7 +148,7 @@ class DummyCam(Instrument):
                 registry.syncDimensionData(
                     "detector",
                     dict(
-                        dataId,
+                        instrument=self.getName(),
                         id=d,
                         full_name=f"RXX_S0{d}",
                     ),


### PR DESCRIPTION
We were passing a lot of instrument record fields to detector record construction, and DimensionRecord is no longer accepting things it does not recognize.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes` (in `daf_butler`)
