### PR TITLE
DM-41846: Use the test ID as the unique component of the test run collection

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
       - id: trailing-whitespace
       - id: check-toml
   - repo: https://github.com/psf/black
-    rev: 23.10.1
+    rev: 23.11.0
     hooks:
       - id: black
         # It is recommended to specify the latest version of Python
@@ -22,6 +22,6 @@ repos:
         name: isort (python)
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.1.2
+    rev: v0.1.6
     hooks:
       - id: ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@
 
 [tool.black]
 line-length = 110
-target-version = ["py310"]
+target-version = ["py311"]
 
 [tool.isort]
 profile = "black"
@@ -77,7 +77,7 @@ select = [
     "W",  # pycodestyle
     "D",  # pydocstyle
 ]
-target-version = "py310"
+target-version = "py311"
 extend-select = [
     "RUF100", # Warn about unused noqa
 ]

--- a/tests/test_butlerFits.py
+++ b/tests/test_butlerFits.py
@@ -150,7 +150,7 @@ class ButlerFitsTests(lsst.utils.tests.TestCase):
             shutil.rmtree(cls.root, ignore_errors=True)
 
     def setUp(self):
-        self.butler = makeTestCollection(self.creatorButler)
+        self.butler = makeTestCollection(self.creatorButler, uniqueId=self.id())
 
     def makeExampleCatalog(self) -> lsst.afw.table.SourceCatalog:
         catalogPath = os.path.join(TESTDIR, "data", "source_catalog.fits")

--- a/tests/test_defineVisits.py
+++ b/tests/test_defineVisits.py
@@ -45,7 +45,7 @@ class DefineVisitsTestCase(unittest.TestCase):
         """
         self.root = tempfile.mkdtemp(dir=TESTDIR)
         self.creatorButler = butlerTests.makeTestRepo(self.root, [])
-        self.butler = butlerTests.makeTestCollection(self.creatorButler)
+        self.butler = butlerTests.makeTestCollection(self.creatorButler, uniqueId=self.id())
 
         self.config = DefineVisitsTask.ConfigClass()
         self.task = DefineVisitsTask(config=self.config, butler=self.butler)

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -111,7 +111,7 @@ datastore:
             shutil.rmtree(cls.root, ignore_errors=True)
 
     def setUp(self):
-        self.butler = butlerTests.makeTestCollection(self.creatorButler)
+        self.butler = butlerTests.makeTestCollection(self.creatorButler, uniqueId=self.id())
         self.outputRun = self.butler.run
 
         config = RawIngestTask.ConfigClass()

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -433,7 +433,7 @@ class TestRawIngestTaskPickle(unittest.TestCase):
             shutil.rmtree(cls.root, ignore_errors=True)
 
     def setUp(self):
-        self.butler = butlerTests.makeTestCollection(self.creatorButler)
+        self.butler = butlerTests.makeTestCollection(self.creatorButler, uniqueId=self.id())
 
         self.config = RawIngestTask.ConfigClass()
         self.config.transfer = "copy"  # safe non-default value


### PR DESCRIPTION
This is a reasonable thing to do in general, but is important when using pytest-randomly because when using that plugin without the --randomly-dont-reset-seed flag, the seed is forced to the global value before every test is run. This leads to makeTestCollection returning the same random integer for every test and the runs clash in the shared repo.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
