### PR TITLE
DM-42012: Enable reading sub-regions and components for MaskedImage

### DIFF
--- a/tests/test_butlerFits.py
+++ b/tests/test_butlerFits.py
@@ -1,4 +1,4 @@
-# This file is part of daf_butler.
+# This file is part of obs_base.
 #
 # Developed for the LSST Data Management System.
 # This product includes software developed by the LSST Project

--- a/tests/test_cliCmdDefineVisits.py
+++ b/tests/test_cliCmdDefineVisits.py
@@ -1,4 +1,4 @@
-# This file is part of daf_butler.
+# This file is part of obs_base.
 #
 # Developed for the LSST Data Management System.
 # This product includes software developed by the LSST Project

--- a/tests/test_cliCmdTestIngest.py
+++ b/tests/test_cliCmdTestIngest.py
@@ -1,4 +1,4 @@
-# This file is part of daf_butler.
+# This file is part of obs_base.
 #
 # Developed for the LSST Data Management System.
 # This product includes software developed by the LSST Project

--- a/tests/test_cliCmdWriteCuratedCalibrations.py
+++ b/tests/test_cliCmdWriteCuratedCalibrations.py
@@ -1,4 +1,4 @@
-# This file is part of daf_butler.
+# This file is part of obs_base.
 #
 # Developed for the LSST Data Management System.
 # This product includes software developed by the LSST Project

--- a/tests/test_cliLog.py
+++ b/tests/test_cliLog.py
@@ -1,4 +1,4 @@
-# This file is part of daf_butler.
+# This file is part of obs_base.
 #
 # Developed for the LSST Data Management System.
 # This product includes software developed by the LSST Project


### PR DESCRIPTION
## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
