### PR TITLE
DM-42340: Use pydantic v2 APIs to remove deprecation warnings

### DIFF
--- a/python/lsst/obs/base/instrument_tests.py
+++ b/python/lsst/obs/base/instrument_tests.py
@@ -37,7 +37,6 @@ __all__ = [
 
 import abc
 import dataclasses
-import json
 from collections.abc import Sequence
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any, ClassVar
@@ -91,11 +90,11 @@ class CuratedCalibration(BaseModel):
     def readText(cls, path: str) -> CuratedCalibration:
         with open(path) as f:
             data = f.read()
-        return cls.parse_obj(json.loads(data))
+        return cls.model_validate_json(data)
 
     def writeText(self, path: str) -> None:
         with open(path, "w") as f:
-            print(self.json(), file=f)
+            print(self.model_dump_json(), file=f)
 
     def getMetadata(self) -> dict[str, Any]:
         return self.metadata

--- a/tests/test_defineVisits.py
+++ b/tests/test_defineVisits.py
@@ -56,7 +56,8 @@ class DefineVisitsTestCase(unittest.TestCase):
         # Read the exposure records.
         self.records: dict[int, DimensionRecord] = {}
         for i in (347, 348, 349):
-            simple = SerializedDimensionRecord.parse_file(os.path.join(DATADIR, f"exp_{i}.json"))
+            with open(os.path.join(DATADIR, f"exp_{i}.json")) as fh:
+                simple = SerializedDimensionRecord.model_validate_json(fh.read())
             self.records[i] = DimensionRecord.from_simple(simple, registry=self.butler.registry)
 
     def tearDown(self):


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
