### PR TITLE
DM-43103: Add support for can_see_sky metadata on ingest

### DIFF
--- a/python/lsst/obs/base/_instrument.py
+++ b/python/lsst/obs/base/_instrument.py
@@ -625,6 +625,7 @@ def makeExposureRecordFromObsInfo(
         ("has_simulated", "has_simulated_content"),
         ("seq_start", "group_counter_start"),
         ("seq_end", "group_counter_end"),
+        ("can_see_sky", "can_see_sky"),
     ):
         if meta_key in supported:
             extras[meta_key] = getattr(obsInfo, info_key)

--- a/python/lsst/obs/base/ingest.py
+++ b/python/lsst/obs/base/ingest.py
@@ -519,6 +519,7 @@ class RawIngestTask(Task):
             "observing_day_offset",
             "science_program",
             "visit_id",
+            "can_see_sky",
         }
         return required, optional
 


### PR DESCRIPTION
Relates to lsst/astro_metadata_translator#73 and lsst/daf_butler#979

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
