### PR TITLE
DM-45738: Force collections to a list to ensure compatibility

### DIFF
--- a/python/lsst/obs/base/_instrument.py
+++ b/python/lsst/obs/base/_instrument.py
@@ -713,7 +713,7 @@ def loadCamera(butler: Butler, dataId: DataId, *, collections: Any = None) -> tu
         Raised when ``dataId`` does not specify a valid data ID.
     """
     if collections is None:
-        collections = butler.collections
+        collections = list(butler.collections)
     # Registry would do data ID expansion internally if we didn't do it first,
     # but we might want an expanded data ID ourselves later, so we do it here
     # to ensure it only happens once.

--- a/python/lsst/obs/base/defineVisits.py
+++ b/python/lsst/obs/base/defineVisits.py
@@ -1214,7 +1214,7 @@ class _ComputeVisitRegionsFromSingleRawWcsTask(ComputeVisitRegionsTask):
             sphere representing that detector's corners projected onto the sky.
         """
         if collections is None:
-            collections = self.butler.collections
+            collections = list(self.butler.collections)
         camera, versioned = loadCamera(self.butler, exposure.dataId, collections=collections)
         if not versioned and self.config.requireVersionedCamera:
             raise LookupError(f"No versioned camera found for exposure {exposure.dataId}.")

--- a/tests/test_defineVisits.py
+++ b/tests/test_defineVisits.py
@@ -197,7 +197,7 @@ class DefineVisitsTestCase(unittest.TestCase, DefineVisitsBase):
         self.assertEqual(self.task.log.name, copy.log.name)
         self.assertEqual(self.task.config, copy.config)
         self.assertEqual(self.task.butler._config, copy.butler._config)
-        self.assertEqual(self.task.butler.collections, copy.butler.collections)
+        self.assertEqual(list(self.task.butler.collections), list(copy.butler.collections))
         self.assertEqual(self.task.butler.run, copy.butler.run)
         self.assertEqual(self.task.universe, copy.universe)
 

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -467,7 +467,7 @@ class TestRawIngestTaskPickle(unittest.TestCase):
         self.assertEqual(self.task.log.name, copy.log.name)
         self.assertEqual(self.task.config, copy.config)
         self.assertEqual(self.task.butler._config, copy.butler._config)
-        self.assertEqual(self.task.butler.collections, copy.butler.collections)
+        self.assertEqual(list(self.task.butler.collections), list(copy.butler.collections))
         self.assertEqual(self.task.butler.run, copy.butler.run)
         self.assertEqual(self.task.universe, copy.universe)
         self.assertEqual(self.task.datasetType, copy.datasetType)


### PR DESCRIPTION
In old butler it's only a Sequence but in new butler it's a ButlerCollection which has no __eq__ implementation. List works for both.

Triggered by lsst/daf_butler#1053

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
