### PR TITLE
DM-46599: Stop using deprecated Butler.collections property

### DIFF
--- a/python/lsst/obs/base/_instrument.py
+++ b/python/lsst/obs/base/_instrument.py
@@ -701,9 +701,9 @@ def loadCamera(butler: Butler, dataId: DataId, *, collections: Any = None) -> tu
         Data ID that identifies at least the ``instrument`` and ``exposure``
         dimensions.
     collections : Any, optional
-        Collections to be searched, overriding ``self.butler.collections``.
-        Can be any of the types supported by the ``collections`` argument
-        to butler construction.
+        Collections to be searched, overriding
+        ``self.butler.collections.defaults``.  Can be any of the types
+        supported by the ``collections`` argument to butler construction.
 
     Returns
     -------
@@ -722,7 +722,7 @@ def loadCamera(butler: Butler, dataId: DataId, *, collections: Any = None) -> tu
         Raised when ``dataId`` does not specify a valid data ID.
     """
     if collections is None:
-        collections = list(butler.collections)
+        collections = list(butler.collections.defaults)
     # Registry would do data ID expansion internally if we didn't do it first,
     # but we might want an expanded data ID ourselves later, so we do it here
     # to ensure it only happens once.

--- a/python/lsst/obs/base/defineVisits.py
+++ b/python/lsst/obs/base/defineVisits.py
@@ -357,7 +357,7 @@ class ComputeVisitRegionsTask(Task, metaclass=ABCMeta):
             Struct describing the visit and the exposures associated with it.
         collections : Any, optional
             Collections to be searched for raws and camera geometry, overriding
-            ``self.butler.collections``.
+            ``self.butler.collections.defaults``.
             Can be any of the types supported by the ``collections`` argument
             to butler construction.
 
@@ -479,7 +479,7 @@ class DefineVisitsTask(Task):
             constituent exposures.
         collections : Any, optional
             Collections to be searched for raws and camera geometry, overriding
-            ``self.butler.collections``.
+            ``self.butler.collections.defaults``.
             Can be any of the types supported by the ``collections`` argument
             to butler construction.
 
@@ -637,7 +637,7 @@ class DefineVisitsTask(Task):
             instrument, and are expected to be on-sky science exposures.
         collections : Any, optional
             Collections to be searched for raws and camera geometry, overriding
-            ``self.butler.collections``.
+            ``self.butler.collections.defaults``.
             Can be any of the types supported by the ``collections`` argument
             to butler construction.
         update_records : `bool`, optional
@@ -1203,7 +1203,7 @@ class _ComputeVisitRegionsFromSingleRawWcsTask(ComputeVisitRegionsTask):
             Dimension record for the exposure.
         collections : Any, optional
             Collections to be searched for raws and camera geometry, overriding
-            ``self.butler.collections``.
+            ``self.butler.collections.defaults``.
             Can be any of the types supported by the ``collections`` argument
             to butler construction.
 
@@ -1214,7 +1214,7 @@ class _ComputeVisitRegionsFromSingleRawWcsTask(ComputeVisitRegionsTask):
             sphere representing that detector's corners projected onto the sky.
         """
         if collections is None:
-            collections = list(self.butler.collections)
+            collections = list(self.butler.collections.defaults)
         camera, versioned = loadCamera(self.butler, exposure.dataId, collections=collections)
         if not versioned and self.config.requireVersionedCamera:
             raise LookupError(f"No versioned camera found for exposure {exposure.dataId}.")

--- a/tests/test_defineVisits.py
+++ b/tests/test_defineVisits.py
@@ -197,7 +197,7 @@ class DefineVisitsTestCase(unittest.TestCase, DefineVisitsBase):
         self.assertEqual(self.task.log.name, copy.log.name)
         self.assertEqual(self.task.config, copy.config)
         self.assertEqual(self.task.butler._config, copy.butler._config)
-        self.assertEqual(list(self.task.butler.collections), list(copy.butler.collections))
+        self.assertEqual(list(self.task.butler.collections.defaults), list(copy.butler.collections.defaults))
         self.assertEqual(self.task.butler.run, copy.butler.run)
         self.assertEqual(self.task.universe, copy.universe)
 

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -467,7 +467,7 @@ class TestRawIngestTaskPickle(unittest.TestCase):
         self.assertEqual(self.task.log.name, copy.log.name)
         self.assertEqual(self.task.config, copy.config)
         self.assertEqual(self.task.butler._config, copy.butler._config)
-        self.assertEqual(list(self.task.butler.collections), list(copy.butler.collections))
+        self.assertEqual(list(self.task.butler.collections.defaults), list(copy.butler.collections.defaults))
         self.assertEqual(self.task.butler.run, copy.butler.run)
         self.assertEqual(self.task.universe, copy.universe)
         self.assertEqual(self.task.datasetType, copy.datasetType)


### PR DESCRIPTION
This was replaced with butler.collections.defaults in RFC-1040.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
