### PR TITLE
DM-47673: v28 release notes (cherry-picked)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,13 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
       - id: check-toml
   - repo: https://github.com/psf/black
-    rev: 24.4.2
+    rev: 24.10.0
     hooks:
       - id: black
         # It is recommended to specify the latest version of Python
@@ -22,6 +22,6 @@ repos:
         name: isort (python)
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.5.4
+    rev: v0.7.4
     hooks:
       - id: ruff

--- a/doc/changes/DM-46297.api.md
+++ b/doc/changes/DM-46297.api.md
@@ -1,3 +1,0 @@
-The `butler write-curated-calibrations` command now requires at least one "label" to be included for the collection name.
-
-This prevents the common mistake of setting up `<instrument>/calib` as a `CALIBRATION` collection rather than a more maintainable `CHAINED` collection.

--- a/doc/lsst.obs.base/CHANGES.rst
+++ b/doc/lsst.obs.base/CHANGES.rst
@@ -1,3 +1,14 @@
+obs_base v28.0.0 (2024-11-21)
+=============================
+
+API Changes
+-----------
+
+- The ``butler write-curated-calibrations`` command now requires at least one "label" to be included for the collection name.
+
+  This prevents the common mistake of setting up ``<instrument>/calib`` as a ``CALIBRATION`` collection rather than a more maintainable ``CHAINED`` collection. (`DM-46297 <https://rubinobs.atlassian.net/browse/DM-46297>`_)
+
+
 obs_base v27.0.0 (2024-06-05)
 =============================
 


### PR DESCRIPTION
## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
