### PR TITLE
DM-48836: Shorten provenance values in FITS headers if too long for astropy

### DIFF
--- a/python/lsst/obs/base/formatters/fitsGeneric.py
+++ b/python/lsst/obs/base/formatters/fitsGeneric.py
@@ -63,5 +63,8 @@ class FitsGenericFormatter(FormatterV2):
         else:
             # Unable to find compliant metadata attribute.
             return in_memory_dataset
-        add_provenance_to_fits_header(metadata, self.dataset_ref, provenance)
+        # Sometimes astropy is used to write FITS headers and astropy
+        # cannot write long HIERARCH values. Therefore always elide some
+        # of the provenance just in case astropy is used.
+        add_provenance_to_fits_header(metadata, self.dataset_ref, provenance, allow_long_headers=False)
         return in_memory_dataset


### PR DESCRIPTION
Astropy.io.fits cannot write HIERARCH+CONTINUE headers and so fails to write provenance headers if, for example, RUN names are too long. Since FitsGenericFormatter might be using astropy we always try to fit in 80 characters for that.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
