### PR TITLE
DM-49674 (v29): Add v29 release notes

### DIFF
--- a/doc/changes/DM-35396.feature.rst
+++ b/doc/changes/DM-35396.feature.rst
@@ -1,1 +1,0 @@
-Modified the FITS-based formatters to write out dataset provenance in the output FITS header.

--- a/doc/changes/DM-47365.feature.rst
+++ b/doc/changes/DM-47365.feature.rst
@@ -1,1 +1,0 @@
-Added a new dataset type for defects that are manually defined.

--- a/doc/lsst.obs.base/CHANGES.rst
+++ b/doc/lsst.obs.base/CHANGES.rst
@@ -1,3 +1,13 @@
+obs_base v29.0.0 (2025-03-26)
+=============================
+
+New Features
+------------
+
+- Modified the FITS-based formatters to write out dataset provenance in the output FITS header. (`DM-35396 <https://rubinobs.atlassian.net/browse/DM-35396>`_)
+- Added a new dataset type for defects that are manually defined. (`DM-47365 <https://rubinobs.atlassian.net/browse/DM-47365>`_)
+
+
 obs_base v28.0.0 (2024-11-21)
 =============================
 


### PR DESCRIPTION
## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
