### PR TITLE
DM-49807: Fix bug whereby the astropy optimization can trigger for all gets

### DIFF
--- a/python/lsst/obs/base/formatters/fitsExposure.py
+++ b/python/lsst/obs/base/formatters/fitsExposure.py
@@ -550,6 +550,11 @@ class FitsExposureFormatter(FitsMaskedImageFormatter):
         # For now only support small non-pixel components. In future
         # could work with cutouts.
         self._reader = None  # Guarantee things are reset.
+
+        # Full read, always use local file read.
+        if not component and not self.checked_parameters:
+            return NotImplemented
+
         if not _ALWAYS_USE_ASTROPY_FOR_COMPONENT_READ and uri.isLocal:
             # For a local URI allow afw to read it directly.
             return NotImplemented

--- a/tests/test_butlerFits.py
+++ b/tests/test_butlerFits.py
@@ -70,6 +70,12 @@ datastore:
   composites:
     disassembled:
       ExposureCompositeF: True
+  # Always run with cache disabled. None of these datasets are remote but
+  # we want to check that URI reading does work properly.
+  cached:
+    expiry:
+      default: false
+      mode: disabled
 """
 
 # Components present in the test file


### PR DESCRIPTION
This happened if caching was disabled and the URI reader was used. The logging for checking whether a bbox parameter was given was assuming that some other parameters were given.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
