### PR TITLE
DM-49845: Update v29 release notes

### DIFF
--- a/doc/changes/DM-49845.misc.rst
+++ b/doc/changes/DM-49845.misc.rst
@@ -1,1 +1,0 @@
-Fixed problem ingesting on-sky raws into a Postgres database with numpy 2.

--- a/doc/lsst.obs.base/CHANGES.rst
+++ b/doc/lsst.obs.base/CHANGES.rst
@@ -7,6 +7,10 @@ New Features
 - Modified the FITS-based formatters to write out dataset provenance in the output FITS header. (`DM-35396 <https://rubinobs.atlassian.net/browse/DM-35396>`_)
 - Added a new dataset type for defects that are manually defined. (`DM-47365 <https://rubinobs.atlassian.net/browse/DM-47365>`_)
 
+Other Changes and Additions
+---------------------------
+
+- Fixed problem ingesting on-sky raws into a Postgres database with numpy 2. (`DM-49845 <https://rubinobs.atlassian.net/browse/DM-49845>`_)
 
 obs_base v28.0.0 (2024-11-21)
 =============================


### PR DESCRIPTION
Ticket was backported to v29 so has to appear in v29 release notes and should not appear in v30 release notes.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
