### PR TITLE
DM-50167: Do not create visits if we know the exposure is not looking at sky

### DIFF
--- a/doc/changes/DM-50167.misc.rst
+++ b/doc/changes/DM-50167.misc.rst
@@ -1,0 +1,1 @@
+Adjusted the logic for visit definition such that a visit will not be defined if it is known that the observation was not looking at the sky (such as with closed-dome tests).

--- a/python/lsst/obs/base/defineVisits.py
+++ b/python/lsst/obs/base/defineVisits.py
@@ -681,7 +681,16 @@ class DefineVisitsTask(Task):
         for dataId in data_id_set:
             record = dataId.records["exposure"]
             assert record is not None, "Guaranteed by expandDataIds call earlier."
-            if record.tracking_ra is None or record.tracking_dec is None or record.sky_angle is None:
+            # LSSTCam data can assign ra/dec to flats, and dome-closed
+            # engineering tests. Do not assign a visit if we know that
+            # can_see_sky is False. Treat None as True for this test.
+            can_see_sky = getattr(record, "can_see_sky", True)
+            if (
+                record.tracking_ra is None
+                or record.tracking_dec is None
+                or record.sky_angle is None
+                or can_see_sky is False
+            ):
                 if self.config.ignoreNonScienceExposures:
                     continue
                 else:


### PR DESCRIPTION
LSSTCam can report tracking_radec values for flats and engineering tests.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
