### PR TITLE
DM-51381: Ensure subTest arguments are strings.

### DIFF
--- a/python/lsst/obs/base/cli/doc/butlerCmdDocGen.py
+++ b/python/lsst/obs/base/cli/doc/butlerCmdDocGen.py
@@ -23,14 +23,16 @@
 subcommand plugins that are provided by this package.
 """
 
+from typing import cast
+
 import click
 
-from lsst.utils import doImport
+from lsst.utils import doImportType
 
 from .. import cmd
 
 
-class ButlerCmdDocGen(click.MultiCommand):
+class ButlerCmdDocGen(click.Group):
     """Provide access of butler subcommand plugins to Sphinx."""
 
     def list_commands(self, ctx):
@@ -48,22 +50,22 @@ class ButlerCmdDocGen(click.MultiCommand):
         """
         return cmd.__all__
 
-    def get_command(self, context, name):
+    def get_command(self, ctx: click.Context, cmd_name: str) -> click.Command | None:
         """Get a click command provided by this package.
 
         Parameters
         ----------
-        ctx : click.Context
+        ctx : `click.Context`
             The current Click context.
-        name : string
+        cmd_name : `str`
             The name of the command to return.
 
         Returns
         -------
-        command : click.Command
+        command : `click.Command`
             A Command that wraps a callable command function.
         """
-        return doImport("lsst.obs.base.cli.cmd." + name)
+        return cast(click.Command | None, doImportType("lsst.obs.base.cli.cmd." + cmd_name))
 
 
 @click.command(cls=ButlerCmdDocGen)

--- a/tests/test_butlerFits.py
+++ b/tests/test_butlerFits.py
@@ -425,7 +425,7 @@ class ButlerFitsTests(lsst.utils.tests.TestCase):
             # parameters that should all do the same thing.
             for amp_parameter in [amp, amp.getName(), n]:
                 for parameters in [{"amp": amp_parameter}, {"amp": amp_parameter, "detector": detector}]:
-                    with self.subTest(parameters=parameters):
+                    with self.subTest(parameters=repr(parameters)):
                         test_trimmed = self.butler.get(trimmed_ref, parameters=parameters)
                         test_untrimmed = self.butler.get(untrimmed_ref, parameters=parameters)
                         self.assertImagesEqual(test_trimmed.image, trimmed_full[amp.getBBox()].image)
@@ -497,7 +497,7 @@ class ButlerFitsTests(lsst.utils.tests.TestCase):
             {"bbox": Box2I(minimum=Point2I(3, 3), maximum=Point2I(21, 16)), "origin": LOCAL},
         ):
             bbox = parameters.get("bbox", reader.readBBox())
-            with self.subTest(parameters=parameters):
+            with self.subTest(parameters=repr(parameters)):
                 # Check that the reader supports reading sub-regions.
                 subMaskedImage = reader.read(**parameters)
                 self.assertImagesEqual(subMaskedImage.image, mi.image[bbox])

--- a/tests/test_fitsRawFormatter.py
+++ b/tests/test_fitsRawFormatter.py
@@ -223,7 +223,7 @@ class FitsRawFormatterTestCase(lsst.utils.tests.TestCase):
             for n, amp in enumerate(detector):
                 for amp_parameter in [amp, amp.getName(), n]:
                     for parameters in [{"amp": amp_parameter}, {"amp": amp_parameter, "detector": detector}]:
-                        with self.subTest(parameters=parameters):
+                        with self.subTest(parameters=repr(parameters)):
                             # Make a new formatter that points at the new file
                             # and has the right parameters.
                             formatter = SimpleFitsRawFormatter(


### PR DESCRIPTION
pytest-xdist chokes on the error messages otherwise, replacing the real problem with an opaque DumpError.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
