### PR TITLE
DM-52398: Fix test for findDataset behavior change

### DIFF
--- a/tests/test_butlerFits.py
+++ b/tests/test_butlerFits.py
@@ -326,7 +326,11 @@ class ButlerFitsTests(lsst.utils.tests.TestCase):
                 # Equality for PSF does not work
                 pass
             elif compName == "filter":
-                self.assertEqual(component, reference, compName)
+                # FilterLabel has different values depending whether you load
+                # it using a ref with full data ID values or not.  With a full
+                # data ID value, it uses the physical_filter data ID value
+                # instead of reading it from the file.
+                self.assertTrue(component.physicalLabel == "d-r" or component.physicalLabel == "HSC-I")
             elif compName == "id":
                 self.assertEqual(component, reference, compName)
             elif compName == "visitInfo":


### PR DESCRIPTION
Fixed a test failure caused by the fact that `Butler.registry.findDataset` now always returns  full data ID values when looking up a dataset.  The test calexp.fits file has an older format for its filter component, which causes the resulting value to vary depending on the data ID value used in the get() call.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
