### PR TITLE
DM-54634: add options to efficiently fix missing visit_detector_region in define-visits

### DIFF
--- a/doc/changes/DM-54634.feature.md
+++ b/doc/changes/DM-54634.feature.md
@@ -1,0 +1,1 @@
+Added `--prefilter` and `--check-detector-regions` options to `butler define-visits` for recovering cases where regions for some detectors are missing due to incomplete transfers.

--- a/python/lsst/obs/base/_fitsRawFormatterBase.py
+++ b/python/lsst/obs/base/_fitsRawFormatterBase.py
@@ -335,6 +335,7 @@ class FitsRawFormatterBase(FitsImageFormatterBase):
             Object that identifies the filter for this image.
         """
         physical = self.observationInfo.physical_filter
+        assert physical is not None
         filter_definitions = self.filterDefinitions
         assert filter_definitions is not None
         band = filter_definitions.physical_to_band[physical]
@@ -350,8 +351,10 @@ class FitsRawFormatterBase(FitsImageFormatterBase):
         elif component == "visitInfo":
             return self.makeVisitInfo()
         elif component == "detector":
+            assert self.observationInfo.detector_num is not None
             return self.getDetector(self.observationInfo.detector_num)
         elif component == "wcs":
+            assert self.observationInfo.detector_num is not None
             detector = self.getDetector(self.observationInfo.detector_num)
             visitInfo = self.makeVisitInfo()
             return self.makeWcs(visitInfo, detector)
@@ -362,6 +365,7 @@ class FitsRawFormatterBase(FitsImageFormatterBase):
 
     def readFull(self) -> Any:
         # Docstring inherited.
+        assert self.observationInfo.detector_num is not None
         amplifier, detector, _ = standardizeAmplifierParameters(
             self.checked_parameters,
             self.getDetector(self.observationInfo.detector_num),

--- a/python/lsst/obs/base/_instrument.py
+++ b/python/lsst/obs/base/_instrument.py
@@ -660,6 +660,7 @@ def makeExposureRecordFromObsInfo(
         ra = float(icrs.ra.degree)
         dec = float(icrs.dec.degree)
         if obsInfo.boresight_rotation_coord == "sky":
+            assert obsInfo.boresight_rotation_angle is not None
             sky_angle = float(obsInfo.boresight_rotation_angle.degree)
     if obsInfo.altaz_begin is not None:
         zenith_angle = float(obsInfo.altaz_begin.zen.degree)
@@ -691,6 +692,7 @@ def makeExposureRecordFromObsInfo(
     # timespan that will not work correctly with calibration lookups. Instead
     # force the end time to be the begin time.
     datetime_end = obsInfo.datetime_end
+    assert obsInfo.datetime_begin is not None
     if datetime_end < obsInfo.datetime_begin:
         datetime_end = obsInfo.datetime_begin
         _LOG.warning(
@@ -699,6 +701,7 @@ def makeExposureRecordFromObsInfo(
             obsInfo.observation_id,
         )
 
+    assert obsInfo.exposure_time_requested is not None
     return dimension.RecordClass(
         instrument=obsInfo.instrument,
         id=obsInfo.exposure_id,

--- a/python/lsst/obs/base/cli/cmd/commands.py
+++ b/python/lsst/obs/base/cli/cmd/commands.py
@@ -83,6 +83,15 @@ fits_re = r"\.fit[s]?\b"
     "with a different value and you are not sure whether to accept the new "
     "value. Ignored if incremental or update mode is enabled.",
 )
+@click.option(
+    "--prefilter/--no-prefilter",
+    default=False,
+    help=(
+        "Whether to filter out exposures that are already associated with a visit before computing "
+        "the visits they would be associated with now.  This is incompatible with --update-records and "
+        "--incremental."
+    ),
+)
 @options_file_option()
 def define_visits(*args: Any, **kwargs: Any) -> None:
     """Define visits from exposures in the butler registry.

--- a/python/lsst/obs/base/cli/cmd/commands.py
+++ b/python/lsst/obs/base/cli/cmd/commands.py
@@ -92,6 +92,14 @@ fits_re = r"\.fit[s]?\b"
         "--incremental."
     ),
 )
+@click.option(
+    "--check-detector-regions/--no-check-detector-regions",
+    default=False,
+    help=(
+        "Whether to check that already-defined visits have the full set of detector regions defined, "
+        "in order to insert missing ones."
+    ),
+)
 @options_file_option()
 def define_visits(*args: Any, **kwargs: Any) -> None:
     """Define visits from exposures in the butler registry.

--- a/python/lsst/obs/base/defineVisits.py
+++ b/python/lsst/obs/base/defineVisits.py
@@ -44,7 +44,7 @@ from typing import Any, ClassVar, TypeVar, cast
 
 import lsst.geom
 from lsst.afw.cameraGeom import FOCAL_PLANE, PIXELS
-from lsst.daf.butler import Butler, DataId, DimensionRecord, Progress, Timespan
+from lsst.daf.butler import Butler, DataCoordinate, DataId, DimensionRecord, Progress, Timespan
 from lsst.daf.butler.registry import ConflictingDefinitionError
 from lsst.geom import Box2D
 from lsst.pex.config import Config, Field, makeRegistry, registerConfigurable
@@ -688,7 +688,7 @@ class DefineVisitsTask(Task):
         self.log.info("Preprocessing data IDs.")
         dimensions = self.universe.conform(["exposure"])
 
-        exposure_records: set[DimensionRecord] = set()
+        exposure_records: dict[DataCoordinate, DimensionRecord] = {}
         instruments: set[str] = set()
         instrument_cls_name: str | None = None
         instrument_record: DimensionRecord | None = None
@@ -726,9 +726,9 @@ class DefineVisitsTask(Task):
                     )
             instrument_name = record.instrument
             instruments.add(instrument_name)
-            exposure_records.add(record)
-        # Downstream APIs expect a list of records, not a set.
-        exposures = list(exposure_records)
+            exposure_records[record.dataId] = record
+        # Downstream APIs expect a list of records, not a dict.
+        exposures = list(exposure_records.values())
         if not exposures:
             self.log.info("No on-sky exposures found after filtering.")
             return Struct(n_visits=0, n_skipped=0, n_new=0, n_partially_updated=0, n_fully_updated=0)

--- a/python/lsst/obs/base/defineVisits.py
+++ b/python/lsst/obs/base/defineVisits.py
@@ -634,6 +634,7 @@ class DefineVisitsTask(Task):
         incremental: bool = False,
         skip_conflicting: bool = False,
         prefilter: bool = False,
+        check_detector_regions: bool = False,
     ) -> Struct:
         """Add visit definitions to the registry for the given exposures.
 
@@ -676,6 +677,11 @@ class DefineVisitsTask(Task):
             exposures that may be associated with multiple visits, the
             presence of any existing visit will cause that exposure to be
             skipped entirely.
+        check_detector_regions : `bool`, optional
+            If `True`, check existing visits to see if they have a
+            ``visit_detector_region`` record for every detector.  The default
+            is to assume that if a ``visit`` record is present, the
+            ``visit_detector_region`` records are as well.
 
         Returns
         -------
@@ -744,9 +750,13 @@ class DefineVisitsTask(Task):
             exposure_records[record.dataId] = record
 
         n_filtered = 0
-        if prefilter:
+        visits_with_complete_regions: set[DataCoordinate] | None = None
+        if prefilter or check_detector_regions:
             with self._query_exposures(exposure_records) as query:
-                n_filtered = self._prefilter(exposure_records, query)
+                if check_detector_regions:
+                    visits_with_complete_regions = self._find_visits_with_all_detector_regions(query)
+                if prefilter:
+                    n_filtered = self._prefilter(exposure_records, query, visits_with_complete_regions)
 
         # Downstream APIs expect a list of records, not a dict.
         exposures = list(exposure_records.values())
@@ -828,7 +838,11 @@ class DefineVisitsTask(Task):
                     if not skip_conflicting:
                         raise
                     inserted_or_updated = False
-                if inserted_or_updated or update_records:
+                needs_visit_detector_region_inserts = (
+                    visits_with_complete_regions is not None
+                    and visitRecords.visit.dataId not in visits_with_complete_regions
+                )
+                if inserted_or_updated or update_records or needs_visit_detector_region_inserts:
                     if inserted_or_updated is True:
                         # This is a new visit, not an update to an existing
                         # one, so insert visit definition.
@@ -872,10 +886,19 @@ class DefineVisitsTask(Task):
                     # Cast below is because MyPy can't determine that
                     # inserted_or_updated can only be False if update_records
                     # is True.
-                    elif update_records or "region" in cast(dict, inserted_or_updated):
+                    elif (
+                        update_records
+                        or needs_visit_detector_region_inserts
+                        or "region" in cast(dict, inserted_or_updated)
+                    ):
+                        if needs_visit_detector_region_inserts:
+                            self.log.info(
+                                "Visit %d was missing detector region records.", visitRecords.visit.id
+                            )
                         # Replace visit-detector regions if we were told to
                         # update records explicitly, or if the visit region
-                        # changed in an incremental=True update.
+                        # changed in an incremental=True update, or if this
+                        # visit didn't have complete detector regions.
                         self.butler.registry.insertDimensionData(
                             "visit_detector_region",
                             *visitRecords.visit_detector_region,
@@ -932,12 +955,22 @@ class DefineVisitsTask(Task):
         with self.butler.query() as query:
             yield query.join_data_coordinates(exposure_records.keys())
 
-    def _prefilter(self, exposure_records: dict[DataCoordinate, DimensionRecord], query: Query) -> int:
+    def _prefilter(
+        self,
+        exposure_records: dict[DataCoordinate, DimensionRecord],
+        query: Query,
+        visits_with_complete_regions: set[DataCoordinate] | None,
+    ) -> int:
         n_filtered: int = 0
         exposure_dimension_group = self.butler.dimensions["exposure"].minimal_group
+        visit_dimension_group = self.butler.dimensions["visit"].minimal_group
         for dual_data_id in query.data_ids(["exposure", "visit"]):
-            if exposure_records.pop(dual_data_id.subset(exposure_dimension_group), None) is not None:
-                n_filtered += 1
+            if (
+                visits_with_complete_regions is None
+                or dual_data_id.subset(visit_dimension_group) in visits_with_complete_regions
+            ):
+                if exposure_records.pop(dual_data_id.subset(exposure_dimension_group), None) is not None:
+                    n_filtered += 1
         if n_filtered:
             self.log.info(
                 "Filtered out %d on-sky exposure(s) (of %d) that were already associated with a visit.",
@@ -945,6 +978,24 @@ class DefineVisitsTask(Task):
                 n_filtered + len(exposure_records),
             )
         return n_filtered
+
+    def _find_visits_with_all_detector_regions(self, query: Query) -> set[DataCoordinate]:
+        all_detectors: dict[str, set[int]] = {}
+        for detector_data_id in query.data_ids(["detector"]):
+            all_detectors.setdefault(cast(str, detector_data_id["instrument"]), set()).add(
+                cast(int, detector_data_id["detector"])
+            )
+        visit_dimension_group = self.butler.dimensions["visit"].minimal_group
+        detectors_with_regions_by_visit: dict[DataCoordinate, set[int]] = {}
+        for vdr in query.dimension_records("visit_detector_region"):
+            detectors_with_regions_by_visit.setdefault(vdr.dataId.subset(visit_dimension_group), set()).add(
+                vdr.detector
+            )
+        result: set[DataCoordinate] = set()
+        for visit_data_id, detectors_for_visit in detectors_with_regions_by_visit.items():
+            if len(detectors_for_visit) == len(all_detectors[cast(str, visit_data_id["instrument"])]):
+                result.add(visit_data_id)
+        return result
 
 
 _T = TypeVar("_T")

--- a/python/lsst/obs/base/defineVisits.py
+++ b/python/lsst/obs/base/defineVisits.py
@@ -39,12 +39,14 @@ import math
 import operator
 from abc import ABCMeta, abstractmethod
 from collections import defaultdict
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import Callable, Iterable, Iterator, Sequence
+from contextlib import contextmanager
 from typing import Any, ClassVar, TypeVar, cast
 
 import lsst.geom
 from lsst.afw.cameraGeom import FOCAL_PLANE, PIXELS
 from lsst.daf.butler import Butler, DataCoordinate, DataId, DimensionRecord, Progress, Timespan
+from lsst.daf.butler.queries import Query
 from lsst.daf.butler.registry import ConflictingDefinitionError
 from lsst.geom import Box2D
 from lsst.pex.config import Config, Field, makeRegistry, registerConfigurable
@@ -631,6 +633,7 @@ class DefineVisitsTask(Task):
         update_records: bool = False,
         incremental: bool = False,
         skip_conflicting: bool = False,
+        prefilter: bool = False,
     ) -> Struct:
         """Add visit definitions to the registry for the given exposures.
 
@@ -666,6 +669,13 @@ class DefineVisitsTask(Task):
             visit definition. This can be used if you solely want to define
             visits that were somehow missed previously. It has no effect if
             ``update_records`` is `True` or incremental mode is enabled.
+        prefilter : `bool`, optional
+            If `True`, filter out exposures that already have a visit defined
+            by querying in advance.  This is not compatible with
+            ``incremental=True`` or ``update_records=True``.  Note that for
+            exposures that may be associated with multiple visits, the
+            presence of any existing visit will cause that exposure to be
+            skipped entirely.
 
         Returns
         -------
@@ -676,7 +686,9 @@ class DefineVisitsTask(Task):
             - n_skipped: number of visits that were already present left alone
             - n_new: number of new visits inserted
             - n_fully_updated: number of existing visits fully updated
-            - n_partially_updated: number of visits with non-geometry updates.
+            - n_partially_updated: number of visits with non-geometry updates
+            - n_filtered: number of exposures dropped because they were
+              already associated with visits.
 
         Raises
         ------
@@ -684,6 +696,9 @@ class DefineVisitsTask(Task):
             Raised if a visit ID conflict is detected and the existing visit
             differs from the new one.
         """
+        if prefilter and (update_records or incremental):
+            raise TypeError("prefilter=True cannot be used with update_records=True or incremental=True")
+
         # Normalize, expand, and deduplicate data IDs.
         self.log.info("Preprocessing data IDs.")
         dimensions = self.universe.conform(["exposure"])
@@ -727,11 +742,24 @@ class DefineVisitsTask(Task):
             instrument_name = record.instrument
             instruments.add(instrument_name)
             exposure_records[record.dataId] = record
+
+        n_filtered = 0
+        if prefilter:
+            with self._query_exposures(exposure_records) as query:
+                n_filtered = self._prefilter(exposure_records, query)
+
         # Downstream APIs expect a list of records, not a dict.
         exposures = list(exposure_records.values())
         if not exposures:
             self.log.info("No on-sky exposures found after filtering.")
-            return Struct(n_visits=0, n_skipped=0, n_new=0, n_partially_updated=0, n_fully_updated=0)
+            return Struct(
+                n_visits=0,
+                n_skipped=0,
+                n_new=0,
+                n_partially_updated=0,
+                n_fully_updated=0,
+                n_filtered=n_filtered,
+            )
         if len(instruments) > 1:
             raise RuntimeError(
                 "All data IDs passed to DefineVisitsTask.run must be "
@@ -896,7 +924,27 @@ class DefineVisitsTask(Task):
             n_new=n_new,
             n_fully_updated=n_fully_updated,
             n_partially_updated=n_partially_updated,
+            n_filtered=n_filtered,
         )
+
+    @contextmanager
+    def _query_exposures(self, exposure_records: dict[DataCoordinate, DimensionRecord]) -> Iterator[Query]:
+        with self.butler.query() as query:
+            yield query.join_data_coordinates(exposure_records.keys())
+
+    def _prefilter(self, exposure_records: dict[DataCoordinate, DimensionRecord], query: Query) -> int:
+        n_filtered: int = 0
+        exposure_dimension_group = self.butler.dimensions["exposure"].minimal_group
+        for dual_data_id in query.data_ids(["exposure", "visit"]):
+            if exposure_records.pop(dual_data_id.subset(exposure_dimension_group), None) is not None:
+                n_filtered += 1
+        if n_filtered:
+            self.log.info(
+                "Filtered out %d on-sky exposure(s) (of %d) that were already associated with a visit.",
+                n_filtered,
+                n_filtered + len(exposure_records),
+            )
+        return n_filtered
 
 
 _T = TypeVar("_T")

--- a/python/lsst/obs/base/defineVisits.py
+++ b/python/lsst/obs/base/defineVisits.py
@@ -838,6 +838,7 @@ class DefineVisitsTask(Task):
                     if not skip_conflicting:
                         raise
                     inserted_or_updated = False
+                    self.log.verbose("Skipping visit %d due to conflict.", visitRecords.visit.id)
                 needs_visit_detector_region_inserts = (
                     visits_with_complete_regions is not None
                     and visitRecords.visit.dataId not in visits_with_complete_regions

--- a/python/lsst/obs/base/defineVisits.py
+++ b/python/lsst/obs/base/defineVisits.py
@@ -834,8 +834,9 @@ class DefineVisitsTask(Task):
                         visitRecords.visit,
                         update=(update_records or incremental),
                     )
-                except ConflictingDefinitionError:
+                except ConflictingDefinitionError as err:
                     if not skip_conflicting:
+                        err.add_note(f"on visit {visitDefinition.id}")
                         raise
                     inserted_or_updated = False
                     self.log.verbose("Skipping visit %d due to conflict.", visitRecords.visit.id)

--- a/python/lsst/obs/base/ingest.py
+++ b/python/lsst/obs/base/ingest.py
@@ -1090,6 +1090,7 @@ class RawIngestTask(Task):
         if "day_obs" in exposure.implied:
             if (offset := getattr(obsInfo, "observing_day_offset")) is not None:
                 offset_int = round(offset.to_value("s"))
+                assert obsInfo.observing_day is not None
                 timespan = Timespan.from_day_obs(obsInfo.observing_day, offset_int)
             else:
                 timespan = None

--- a/python/lsst/obs/base/script/defineVisits.py
+++ b/python/lsst/obs/base/script/defineVisits.py
@@ -37,6 +37,7 @@ def defineVisits(
     incremental: bool = False,
     skip_conflicting: bool = False,
     prefilter: bool = False,
+    check_detector_regions: bool = False,
 ) -> None:
     """Implement the command line interface `butler define-visits` subcommand,
     should only be called by command line tools and unit test code that tests
@@ -77,6 +78,11 @@ def defineVisits(
         ``incremental=True`` or ``update_records=True``.  Note that for
         exposures that may be associated with multiple visits, the presence
         of any existing visit will cause that exposure to be skipped entirely.
+    check_detector_regions : `bool`, optional
+        If `True`, check existing visits to see if they have a
+        ``visit_detector_region`` record for every detector.  The default
+        is to assume that if a ``visit`` record is present, the
+        ``visit_detector_region`` records are as well.
 
     Notes
     -----
@@ -122,4 +128,5 @@ def defineVisits(
             incremental=incremental,
             skip_conflicting=skip_conflicting,
             prefilter=prefilter,
+            check_detector_regions=check_detector_regions,
         )

--- a/python/lsst/obs/base/script/defineVisits.py
+++ b/python/lsst/obs/base/script/defineVisits.py
@@ -36,6 +36,7 @@ def defineVisits(
     update_records: bool = False,
     incremental: bool = False,
     skip_conflicting: bool = False,
+    prefilter: bool = False,
 ) -> None:
     """Implement the command line interface `butler define-visits` subcommand,
     should only be called by command line tools and unit test code that tests
@@ -70,6 +71,12 @@ def defineVisits(
         visit definition. This can be used if you solely want to define
         visits that were somehow missed previously. It has no effect if
         ``update_records`` is `True` or incremental mode is enabled.
+    prefilter : `bool`, optional
+        If `True`, filter out exposures that already have a visit defined
+        by querying in advance.  This is not compatible with
+        ``incremental=True`` or ``update_records=True``.  Note that for
+        exposures that may be associated with multiple visits, the presence
+        of any existing visit will cause that exposure to be skipped entirely.
 
     Notes
     -----
@@ -114,4 +121,5 @@ def defineVisits(
             update_records=update_records,
             incremental=incremental,
             skip_conflicting=skip_conflicting,
+            prefilter=prefilter,
         )

--- a/tests/test_cliCmdDefineVisits.py
+++ b/tests/test_cliCmdDefineVisits.py
@@ -51,6 +51,7 @@ class DefineVisitsTest(CliCmdTestBase, unittest.TestCase):
                 update_records=False,
                 incremental=False,
                 skip_conflicting=False,
+                prefilter=False,
             ),
         )
 
@@ -86,6 +87,7 @@ class DefineVisitsTest(CliCmdTestBase, unittest.TestCase):
                 update_records=True,
                 incremental=True,
                 skip_conflicting=True,
+                prefilter=False,
             ),
         )
 

--- a/tests/test_cliCmdDefineVisits.py
+++ b/tests/test_cliCmdDefineVisits.py
@@ -52,6 +52,7 @@ class DefineVisitsTest(CliCmdTestBase, unittest.TestCase):
                 incremental=False,
                 skip_conflicting=False,
                 prefilter=False,
+                check_detector_regions=False,
             ),
         )
 
@@ -88,6 +89,7 @@ class DefineVisitsTest(CliCmdTestBase, unittest.TestCase):
                 incremental=True,
                 skip_conflicting=True,
                 prefilter=False,
+                check_detector_regions=False,
             ),
         )
 

--- a/tests/test_defineVisits.py
+++ b/tests/test_defineVisits.py
@@ -110,7 +110,7 @@ class DefineVisitsBase:
             self.butler.registry.insertDimensionData("exposure", *deduped_records)
             # Include all records so far in definition.
             if self.use_data_ids:
-                dataIds = list(self.butler.registry.queryDataIds("exposure", instrument="DummyCam"))
+                dataIds = sorted(self.butler.registry.queryDataIds("exposure", instrument="DummyCam"))
             else:
                 dataIds = records
 

--- a/tests/test_defineVisits.py
+++ b/tests/test_defineVisits.py
@@ -170,6 +170,20 @@ class DefineVisitsTestCase(unittest.TestCase, DefineVisitsBase):
         self.define_visits([list(self.records.values())], incremental=False)  # list inside a list
         self.assertVisits()
 
+    def test_prefilter(self):
+        self.define_visits([list(self.records.values())], incremental=False)
+        self.assertVisits()
+        with self.assertLogs(level=logging.INFO) as cm:
+            result = self.task.run(self.records.values(), incremental=False, prefilter=True)
+        self.assertIn(
+            f"Filtered out {len(self.records)} on-sky exposure(s) (of {len(self.records)}) that were "
+            "already associated with a visit.",
+            "\n".join(cm.output),
+        )
+        self.assertEqual(result.n_filtered, len(self.records))
+        self.assertEqual(result.n_visits, 0)
+        self.assertEqual(result.n_skipped, 0)
+
     def test_incremental_cumulative(self):
         # Define the visits after each exposure.
         self.define_visits(list(self.records.values()), incremental=True)

--- a/tests/test_defineVisits.py
+++ b/tests/test_defineVisits.py
@@ -29,7 +29,7 @@ import warnings
 from collections import defaultdict
 
 import lsst.daf.butler.tests as butlerTests
-from lsst.daf.butler import DataCoordinate, DimensionRecord, SerializedDimensionRecord
+from lsst.daf.butler import Butler, DataCoordinate, DimensionRecord, SerializedDimensionRecord
 from lsst.daf.butler.registry import ConflictingDefinitionError
 from lsst.obs.base import DefineVisitsConfig, DefineVisitsTask
 from lsst.obs.base.instrument_tests import DummyCam
@@ -183,6 +183,46 @@ class DefineVisitsTestCase(unittest.TestCase, DefineVisitsBase):
         self.assertEqual(result.n_filtered, len(self.records))
         self.assertEqual(result.n_visits, 0)
         self.assertEqual(result.n_skipped, 0)
+
+    def test_check_detector_regions(self):
+        self.define_visits([list(self.records.values())], incremental=False)
+        self.assertVisits()
+        # We can't remove dimension records from a repository, so to test
+        # fixing a case of missing visit_detector regions, we have to make a
+        # new butler repository and transfer only some records to it (this is
+        # actually what happens in the production context where we need this
+        # functionality).
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as new_butler_root:
+            config = Butler.makeRepo(new_butler_root)
+            butler = Butler.from_config(config, writeable=True)
+            # We can't even use transfer_dimension_records_from because that's
+            # too careful to include everything, including the detector
+            # regions.
+            for element_name in (
+                "instrument",
+                "physical_filter",
+                "day_obs",
+                "visit",
+                "group",
+                "exposure",
+                "visit_system",
+                "visit_definition",
+                "visit_system_membership",
+                "detector",
+            ):
+                butler.registry.insertDimensionData(
+                    element_name, *self.butler.query_dimension_records(element_name)
+                )
+            task = DefineVisitsTask(config=self.config, butler=butler)
+            with self.assertLogs(level=logging.INFO) as cm:
+                task.run(
+                    self.records.values(), incremental=False, prefilter=True, check_detector_regions=True
+                )
+            self.assertIn("missing detector region records", "\n".join(cm.output))
+            self.assertCountEqual(
+                butler.query_dimension_records("visit_detector_region"),
+                self.butler.query_dimension_records("visit_detector_region"),
+            )
 
     def test_incremental_cumulative(self):
         # Define the visits after each exposure.


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
